### PR TITLE
[99] enable configurable base URL for beacon destination

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -65,7 +65,7 @@ export function sampleRUM(checkpoint, data = {}) {
       const sendPing = (pdata = data) => {
         // eslint-disable-next-line object-curly-newline, max-len, no-use-before-define
         const body = JSON.stringify({ weight, id, referer: window.hlx.rum.sanitizeURL(), checkpoint, t: (Date.now() - firstReadTime), ...data }, knownProperties);
-        const url = `https://rum.hlx.page/.rum/${weight}`;
+        const url = new URL(`.rum/${weight}`, window.location).href;
         // eslint-disable-next-line no-unused-expressions
         navigator.sendBeacon(url, body);
         // eslint-disable-next-line no-console

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,8 @@
  * for instance the href of a link, or a search term
  */
 export function sampleRUM(checkpoint, data = {}) {
+  sampleRUM.baseURL = sampleRUM.baseURL || window.rumBase || 'https://rum.hlx.page';
+  sampleRUM.baseURL = sampleRUM.baseURL.startsWith('/') ? `${window.location.origin}${sampleRUM.baseURL}` : sampleRUM.baseURL;
   sampleRUM.defer = sampleRUM.defer || [];
   const defer = (fnname) => {
     sampleRUM[fnname] = sampleRUM[fnname]
@@ -65,7 +67,7 @@ export function sampleRUM(checkpoint, data = {}) {
       const sendPing = (pdata = data) => {
         // eslint-disable-next-line object-curly-newline, max-len, no-use-before-define
         const body = JSON.stringify({ weight, id, referer: window.hlx.rum.sanitizeURL(), checkpoint, t: (Date.now() - firstReadTime), ...data }, knownProperties);
-        const url = new URL(`.rum/${weight}`, window.location).href;
+        const url = new URL(`.rum/${weight}`, sampleRUM.baseURL).href;
         // eslint-disable-next-line no-unused-expressions
         navigator.sendBeacon(url, body);
         // eslint-disable-next-line no-console
@@ -76,7 +78,7 @@ export function sampleRUM(checkpoint, data = {}) {
         lazy: () => {
           // use classic script to avoid CORS issues
           const script = document.createElement('script');
-          script.src = 'https://rum.hlx.page/.rum/@adobe/helix-rum-enhancer@^1/src/index.js';
+          script.src = new URL('.rum/@adobe/helix-rum-enhancer@^1/src/index.js', sampleRUM.baseURL).href;
           document.head.appendChild(script);
           return true;
         },

--- a/src/index.js
+++ b/src/index.js
@@ -21,8 +21,7 @@
  * for instance the href of a link, or a search term
  */
 export function sampleRUM(checkpoint, data = {}) {
-  sampleRUM.baseURL = sampleRUM.baseURL || window.rumBase || 'https://rum.hlx.page';
-  sampleRUM.baseURL = sampleRUM.baseURL.startsWith('/') ? `${window.location.origin}${sampleRUM.baseURL}` : sampleRUM.baseURL;
+  sampleRUM.baseURL = sampleRUM.baseURL || new URL(window.RUM_BASE == null ? 'https://rum.hlx.page' : window.RUM_BASE, window.location);
   sampleRUM.defer = sampleRUM.defer || [];
   const defer = (fnname) => {
     sampleRUM[fnname] = sampleRUM[fnname]


### PR DESCRIPTION
See https://cq-dev.slack.com/archives/C04KT8BJR19/p1695188879278689?thread_ts=1694701902.855299&cid=C04KT8BJR19

This assumes that the origin CDN forwards all requests going to `**/.rum/**` to `https://rum.hlx.page/.rum/$2`

As this is not yet the case with `hlx.live` and `hlx.page` we need to think about how to distribute this code variant to users where the routing has been enabled on the CDN level

## Related Issues
#99 