### PR TITLE
feat(minirum): allow increasing the sampling rate up to 1/10 for specific use cases

### DIFF
--- a/docs/STANDALONE-ADVANCED-CONFIG.md
+++ b/docs/STANDALONE-ADVANCED-CONFIG.md
@@ -19,3 +19,4 @@ Please note, that the origin you set, must route `/.rum/*` requests to `https://
 E.g.
 ```javascript
 window.RUM_BASE = window.origin;
+```

--- a/docs/STANDALONE-ADVANCED-CONFIG.md
+++ b/docs/STANDALONE-ADVANCED-CONFIG.md
@@ -19,15 +19,3 @@ Please note, that the origin you set, must route `/.rum/*` requests to `https://
 E.g.
 ```javascript
 window.RUM_BASE = window.origin;
-```
-
-## Adjusting the sampling rate
-
-The default sampling rate for RUM data is 1 out of 100 requests. For some use cases, like when running experiments on low traffic pages, or during specific short-lived marketing campaigns, you may want to sample at a higher rate to gather more data for your reporting.
-You can achieve this by setting the global variable `window.RUM_SAMPLING_RATE` before loading the script.
-Please note that the maximum sampling rate we accept is `10` so we can guarantee the privacy-first principle, and any value > 10 will be accepted.
-
-E.g.
-```javascript
-window.RUM_BASE = 10;
-```

--- a/docs/STANDALONE-ADVANCED-CONFIG.md
+++ b/docs/STANDALONE-ADVANCED-CONFIG.md
@@ -20,3 +20,14 @@ E.g.
 ```javascript
 window.RUM_BASE = window.origin;
 ```
+
+## Adjusting the sampling rate
+
+The default sampling rate for RUM data is 1 out of 100 requests. For some use cases, like when running experiments on low traffic pages, or during specific short-lived marketing campaigns, you may want to sample at a higher rate to gather more data for your reporting.
+You can achieve this by setting the global variable `window.RUM_SAMPLING_RATE` before loading the script.
+Please note that the maximum sampling rate we accept is `10` so we can guarantee the privacy-first principle, and any value > 10 will be accepted.
+
+E.g.
+```javascript
+window.RUM_BASE = 10;
+```

--- a/src/index.js
+++ b/src/index.js
@@ -16,10 +16,10 @@ export function sampleRUM(checkpoint, data) {
   try {
     window.hlx = window.hlx || {};
     if (!window.hlx.rum) {
-      const weight = (window.SAMPLE_PAGEVIEWS_AT_RATE === 'high' && 10) ||
-        (window.SAMPLE_PAGEVIEWS_AT_RATE === 'low' && 1000) ||
-        (new URLSearchParams(window.location.search).get('rum') === 'on' && 1) ||
-        100;
+      const weight = (window.SAMPLE_PAGEVIEWS_AT_RATE === 'high' && 10)
+        || (window.SAMPLE_PAGEVIEWS_AT_RATE === 'low' && 1000)
+        || (new URLSearchParams(window.location.search).get('rum') === 'on' && 1)
+        || 100;
       const id = Math.random().toString(36).slice(-4);
       const isSelected = (Math.random() * weight < 1);
       // eslint-disable-next-line object-curly-newline, max-len

--- a/src/index.js
+++ b/src/index.js
@@ -16,8 +16,12 @@ export function sampleRUM(checkpoint, data) {
   try {
     window.hlx = window.hlx || {};
     if (!window.hlx.rum) {
-      const defaultSamplingRate = Math.max(10, window.RUM_SAMPLING_RATE || 100);
-      const weight = new URLSearchParams(window.location.search).get('rum') === 'on' ? 1 : defaultSamplingRate;
+      // Experiments & marketing campaigns
+      const defaultWeight = document.head.querySelector('[name^="experiment"],[name^="campaign-"],[name^="audience-"]')
+        || [...document.querySelectorAll('.section-metadata div')].some((d) => d.textContent.match(/Experiment|Campaign|Audience/i))
+        ? 10
+        : 100;
+      const weight = new URLSearchParams(window.location.search).get('rum') === 'on' ? 1 : defaultWeight;
       const id = Math.random().toString(36).slice(-4);
       const isSelected = (Math.random() * weight < 1);
       // eslint-disable-next-line object-curly-newline, max-len

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,8 @@ export function sampleRUM(checkpoint, data) {
   try {
     window.hlx = window.hlx || {};
     if (!window.hlx.rum) {
-      const weight = new URLSearchParams(window.location.search).get('rum') === 'on' ? 1 : 100;
+      const defaultSamplingRate = Math.max(10, window.RUM_SAMPLING_RATE || 100);
+      const weight = new URLSearchParams(window.location.search).get('rum') === 'on' ? 1 : defaultSamplingRate;
       const id = Math.random().toString(36).slice(-4);
       const isSelected = (Math.random() * weight < 1);
       // eslint-disable-next-line object-curly-newline, max-len

--- a/src/index.js
+++ b/src/index.js
@@ -16,12 +16,10 @@ export function sampleRUM(checkpoint, data) {
   try {
     window.hlx = window.hlx || {};
     if (!window.hlx.rum) {
-      // Experiments & marketing campaigns
-      const defaultWeight = document.head.querySelector('[name^="experiment"],[name^="campaign-"],[name^="audience-"]')
-        || [...document.querySelectorAll('.section-metadata div')].some((d) => d.textContent.match(/Experiment|Campaign|Audience/i))
-        ? 10
-        : 100;
-      const weight = new URLSearchParams(window.location.search).get('rum') === 'on' ? 1 : defaultWeight;
+      const weight = (window.SAMPLE_PAGEVIEWS_AT_RATE === 'high' && 10) ||
+        (window.SAMPLE_PAGEVIEWS_AT_RATE === 'low' && 1000) ||
+        (new URLSearchParams(window.location.search).get('rum') === 'on' && 1) ||
+        100;
       const id = Math.random().toString(36).slice(-4);
       const isSelected = (Math.random() * weight < 1);
       // eslint-disable-next-line object-curly-newline, max-len

--- a/test/sampleRUM-enabled.test.js
+++ b/test/sampleRUM-enabled.test.js
@@ -98,21 +98,6 @@ describe('sampleRUM', () => {
     });
   });
   describe('sampling rate', () => {
-    let sendBeaconArgs;
-    beforeEach(() => {
-      sendBeaconArgs = {};
-      // eslint-disable-next-line no-underscore-dangle
-      navigator._sendBeacon = navigator.sendBeacon;
-      navigator.sendBeacon = (url, data) => {
-        sendBeaconArgs.url = url;
-        sendBeaconArgs.data = JSON.parse(data);
-        return true;
-      };
-    });
-    afterEach(() => {
-      // eslint-disable-next-line no-underscore-dangle
-      navigator.sendBeacon = navigator._sendBeacon;
-    });
     it('allows high sampling rate', async () => {
       window.SAMPLE_PAGEVIEWS_AT_RATE = 'high';
       sampleRUM();


### PR DESCRIPTION
This introduces a new global variable, `window.RUM_SAMPLING_RATE`, that can be set before loading the library to increase the sampling rate for specific use cases that require more data collected for short-term reporting.
For instance:
- when running an experiment in a 2-week time-frame and achieve statistical significance even with low traffic
- when running short-lived marketing campaign and wanting to collect enough data over a single weekend

## Usage

For instance:
```js
window.SAMPLE_PAGEVIEWS_AT_RATE = 'high';
```

Or in an HTML context:
```html
  <head>
    <meta name="experiment" content="Foo"/>
    <meta name="experiment-variants" content="/bar,/baz"/>
    <script>window.SAMPLE_PAGEVIEWS_AT_RATE = document.head.querySelector('meta[name="experiment"]') ? 'high' : null</script>
    <script src="/scripts/aem.js" type="module"></script>
    <script src="/scripts/scripts.js" type="module"></script>
    <link rel="stylesheet" href="/styles/styles.css">
  </head>
```
## Related Issues

Fix #156 