### PR TITLE
fix: avoid exceptions on error tracking

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,11 +24,15 @@ export function sampleRUM(checkpoint, data) {
       if (isSelected) {
         ['error', 'unhandledrejection'].forEach((event) => {
           window.addEventListener(event, ({ reason, error }) => {
-            const source = (reason || error).stack.split('\n')
-              .filter((line) => line.match(/https?:\/\//)).shift()
-              .replace(/at ([^ ]+) \((.+)\)/, '$1@$2');
-            const target = (reason || error).toString();
-            sampleRUM('error', { source, target });
+            const errData = {};
+            try {
+              errData.target = (reason || error).toString();
+              errData.source = (reason || error).stack.split('\n')
+                .filter((line) => line.match(/https?:\/\//)).shift()
+                .replace(/at ([^ ]+) \((.+)\)/, '$1@$2')
+                .trim();
+            } catch (err) { /* error structure was not as expected */ }
+            sampleRUM('error', errData);
           });
         });
         sampleRUM.baseURL = sampleRUM.baseURL || new URL(window.RUM_BASE || '/', new URL('https://rum.hlx.page'));

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ export function sampleRUM(checkpoint, data) {
       if (isSelected) {
         ['error', 'unhandledrejection'].forEach((event) => {
           window.addEventListener(event, ({ reason, error }) => {
-            const errData = {};
+            const errData = { source: 'undefined error' };
             try {
               errData.target = (reason || error).toString();
               errData.source = (reason || error).stack.split('\n')


### PR DESCRIPTION
Sometimes error events don't have the expected structure, e.g. error is just a string `Script error` and that causes an exception as there is no `stack`.
The changes in this PR add a try catch block to avoid this situations.
