### PR TITLE
chore(standalone): wrap standalone as a iife

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -38,7 +38,7 @@ export default [...bundles.map(({ outputFile, source }) => ({
   output: [
     {
       file: `${outputFile}.js`,
-      format: 'es',
+      format: 'iife',
       sourcemap: false,
       exports: 'auto',
     },


### PR DESCRIPTION
When RUM is used in Standalone mode and the script is not loaded with `type="module"` the function sampleRUM is defined in the global scope.
This is not desirable and will cause issues if other scripts, such as enhancer, declare the same variable name in the global scope.
With this PR we wrap `sampleRUM` and its invocation in their own function, restricting the scope of the variables defined, but only in the Standalone mode, without modifying the structure for Edge Delivery Services projects. 
