### PR TITLE
fix: immediately load the enhancer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,12 +41,10 @@ export function sampleRUM(checkpoint, data) {
         const body = JSON.stringify({ weight, id, referer: window.location.href, checkpoint: 'top', t: timeShift(), target: document.visibilityState });
         const url = new URL(`.rum/${weight}`, sampleRUM.baseURL).href;
         navigator.sendBeacon(url, body);
-        // get enhancer on load
-        window.addEventListener('load', () => {
-          const script = document.createElement('script');
-          script.src = new URL('.rum/@adobe/helix-rum-enhancer@^2/src/index.js', sampleRUM.baseURL).href;
-          document.head.appendChild(script);
-        });
+
+        const script = document.createElement('script');
+        script.src = new URL('.rum/@adobe/helix-rum-enhancer@^2/src/index.js', sampleRUM.baseURL).href;
+        document.head.appendChild(script);
       }
     }
     if (window.hlx.rum && window.hlx.rum.isSelected && checkpoint) {

--- a/src/index.js
+++ b/src/index.js
@@ -42,9 +42,17 @@ export function sampleRUM(checkpoint, data) {
         const url = new URL(`.rum/${weight}`, sampleRUM.baseURL).href;
         navigator.sendBeacon(url, body);
 
-        const script = document.createElement('script');
-        script.src = new URL('.rum/@adobe/helix-rum-enhancer@^2/src/index.js', sampleRUM.baseURL).href;
-        document.head.appendChild(script);
+        const loadEnhancer = () => {
+          const script = document.createElement('script');
+          script.src = new URL('.rum/@adobe/helix-rum-enhancer@^2/src/index.js', sampleRUM.baseURL).href;
+          document.head.appendChild(script);
+        }
+        if (window.performance && window.performance.getEntriesByType("navigation").every((e) => e.loadEventEnd)) {
+          // load event ended
+          loadEnhancer();
+        } else {
+          window.addEventListener('load', loadEnhancer);
+        }
       }
     }
     if (window.hlx.rum && window.hlx.rum.isSelected && checkpoint) {

--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,7 @@ export function sampleRUM(checkpoint, data) {
         };
 
         if (window.performance && window.performance.getEntriesByType('navigation').every((e) => e.loadEventEnd)) {
-          // load event ended
+          // load event already ended
           loadEnhancer();
         } else {
           window.addEventListener('load', loadEnhancer);

--- a/src/index.js
+++ b/src/index.js
@@ -46,8 +46,9 @@ export function sampleRUM(checkpoint, data) {
           const script = document.createElement('script');
           script.src = new URL('.rum/@adobe/helix-rum-enhancer@^2/src/index.js', sampleRUM.baseURL).href;
           document.head.appendChild(script);
-        }
-        if (window.performance && window.performance.getEntriesByType("navigation").every((e) => e.loadEventEnd)) {
+        };
+
+        if (window.performance && window.performance.getEntriesByType('navigation').every((e) => e.loadEventEnd)) {
           // load event ended
           loadEnhancer();
         } else {

--- a/test/sampleRUM-afterloadevent.test.html
+++ b/test/sampleRUM-afterloadevent.test.html
@@ -1,0 +1,35 @@
+<html>
+  <body>
+    <script type="module">
+      import { runTests } from '@web/test-runner-mocha';
+      import { expect } from '@esm-bundle/chai';
+
+      import { sampleRUM } from '../src/index.js';
+      
+      /* eslint-env mocha */
+      runTests(async () => {
+        describe('sampleRUM - after load event', () => {
+          beforeEach(() => {
+            const usp = new URLSearchParams(window.location.search);
+            usp.append('rum', 'on');
+            window.history.replaceState({}, '', `${window.location.pathname}?${usp.toString()}`);
+          });
+
+          afterEach(() => {
+            const usp = new URLSearchParams(window.location.search);
+            usp.delete('rum');
+            window.history.replaceState({}, '', `${window.location.pathname}?${usp.toString()}`);
+            // eslint-disable-next-line no-underscore-dangle
+            window.hlx.rum = undefined;
+          });
+
+          it('rum selected load enhancer', () => {
+            expect(document.querySelector('script[src*="rum-enhancer"]')).to.not.exist;
+            sampleRUM();
+            expect(document.querySelector('script[src*="rum-enhancer"]')).to.exist;
+          });
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/test/sampleRUM-beforeloadevent.test.html
+++ b/test/sampleRUM-beforeloadevent.test.html
@@ -1,0 +1,30 @@
+<html>
+  <head>
+    <script>
+      const usp = new URLSearchParams(window.location.search);
+      usp.append('rum', 'on');
+      window.history.replaceState({}, '', `${window.location.pathname}?${usp.toString()}`);
+    </script>
+    <script type="module">
+      import { sampleRUM } from '../src/index.js';
+      // early call to sampleRUM, i.e. before load event
+      sampleRUM();
+    </script>
+  </head>
+  <body>
+    <script type="module">
+      import { runTests } from '@web/test-runner-mocha';
+      import { expect } from '@esm-bundle/chai';
+
+      /* eslint-env mocha */
+      runTests(async () => {
+        describe('sampleRUM - load event', () => {
+          it('rum selected load enhancer', () => {
+            // at this stage, rum-enhancer should not loaded because load event already
+            expect(document.querySelector('script[src*="rum-enhancer"]')).to.exist;          
+          });
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/test/sampleRUM.test.js
+++ b/test/sampleRUM.test.js
@@ -30,6 +30,7 @@ describe('sampleRUM', () => {
     // eslint-disable-next-line no-underscore-dangle
     window.hlx.rum = undefined;
   });
+
   it('rum initialization', async () => {
     const sendBeaconArgs = {};
     // eslint-disable-next-line no-underscore-dangle
@@ -47,6 +48,7 @@ describe('sampleRUM', () => {
     // eslint-disable-next-line no-underscore-dangle
     navigator.sendBeacon = navigator._sendBeacon;
   });
+
   it('rum checkpoint queuing', async () => {
     sampleRUM();
     sampleRUM('test', {
@@ -59,6 +61,7 @@ describe('sampleRUM', () => {
     expect(data.int).to.equal(1);
     expect(time).to.exist;
   });
+
   it('rum initialization not selected', async () => {
     const sendBeaconArgs = {};
     // eslint-disable-next-line no-underscore-dangle
@@ -77,6 +80,7 @@ describe('sampleRUM', () => {
     // eslint-disable-next-line no-underscore-dangle
     navigator.sendBeacon = navigator._sendBeacon;
   });
+
   it('rum checkpoint queuing not selected', async () => {
     sampleRUM();
     window.hlx.rum.isSelected = false;
@@ -85,10 +89,5 @@ describe('sampleRUM', () => {
       int: 1,
     });
     expect(window.hlx.rum.queue.length).to.equal(0);
-  });
-  it('rum selected load enhancer', async () => {
-    sampleRUM();
-    window.dispatchEvent(new Event('load'));
-    expect(document.querySelector('script[src*="rum-enhancer"]')).to.exist;
   });
 });


### PR DESCRIPTION
@davidnuescheler and I were looking at the RUM data of the GenStudio and only few data are available. On top of low traffic, we discovered that the enhancer is not loaded.
Reason: the `load` event has already fired.

Relying on the `load` event is problematic, because we do not know when the script `rum-standalone.js` script is loaded. In the GenStudio case, it is pretty late. 
If people follow the instructions to load the script right after the LCP, there is not specific reason to wait for the `load` event to load the enhancer. 
If they add it pre-LCP, the costly DNS lookup and SSL handshake are already done anyway (i.e. to load `rum-standalone.js`), which is another reason to not wait for the `load` event.

For all those reasons, we should get rid of the listener on the `load` event and just immediately include the enhancer.