### PR TITLE
feat: improve errors capture

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,19 +23,35 @@ export function sampleRUM(checkpoint, data) {
       // eslint-disable-next-line object-curly-newline, max-len
       window.hlx.rum = { weight, id, isSelected, firstReadTime: window.performance ? window.performance.timeOrigin : Date.now(), sampleRUM, queue: [], collector: (...args) => window.hlx.rum.queue.push(args) };
       if (isSelected) {
-        ['error', 'unhandledrejection'].forEach((event) => {
-          window.addEventListener(event, ({ reason, error }) => {
-            const errData = { source: 'undefined error' };
-            try {
-              errData.target = (reason || error).toString();
-              errData.source = (reason || error).stack.split('\n')
-                .filter((line) => line.match(/https?:\/\//)).shift()
-                .replace(/at ([^ ]+) \((.+)\)/, '$1@$2')
-                .trim();
-            } catch (err) { /* error structure was not as expected */ }
-            sampleRUM('error', errData);
-          });
+        const dataFromErrorObj = (error) => {
+          const errData = { source: 'undefined error' };
+          try {
+            errData.target = error.toString();
+            errData.source = error.stack.split('\n')
+              .filter((line) => line.match(/https?:\/\//)).shift()
+              .replace(/at ([^ ]+) \((.+)\)/, '$1@$2')
+              .replace(/ at /, '@')
+              .trim();
+          } catch (err) { /* error structure was not as expected */ }
+          return errData;
+        };
+
+        window.addEventListener('error', ({ error }) => {
+          const errData = dataFromErrorObj(error);
+          sampleRUM('error', errData);
         });
+
+        window.addEventListener('unhandledrejection', ({ reason }) => {
+          let errData = {
+            source: 'Unhandled Rejection',
+            target: reason || 'Unknown',
+          };
+          if (reason instanceof Error) {
+            errData = dataFromErrorObj(reason);
+          }
+          sampleRUM('error', errData);
+        });
+
         sampleRUM.baseURL = sampleRUM.baseURL || new URL(window.RUM_BASE || '/', new URL('https://rum.hlx.page'));
         sampleRUM.collectBaseURL = sampleRUM.collectBaseURL || sampleRUM.baseURL;
         sampleRUM.sendPing = (ck, time, pingData = {}) => {

--- a/test/errors/errors.js
+++ b/test/errors/errors.js
@@ -28,7 +28,7 @@ export async function test(errorFct, sourceTest, targetTest, queue) {
   const wait = async () => new Promise((resolve) => {
     window.setTimeout(() => {
       resolve();
-    }, 1000);
+    }, 1500);
   });
 
   await wait();

--- a/test/errors/errors.js
+++ b/test/errors/errors.js
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+import { expect } from '@esm-bundle/chai';
+import { sampleRUM } from '../../src/index.js';
+
+// fires an error on purpose
+export function fireError() {
+  let s;
+  s.t = 1;
+}
+
+export async function test(errorFct, sourceTest, targetTest, queue) {
+  sampleRUM();
+
+  window.setTimeout(errorFct, 1);
+
+  const wait = async () => new Promise((resolve) => {
+    window.setTimeout(() => {
+      resolve();
+    }, 100);
+  });
+
+  await wait();
+
+  expect(queue.length).to.equal(1);
+  const { source, target } = queue[0].data;
+  sourceTest.call(this, source);
+  targetTest.call(this, target);
+}
+
+export function before(config) {
+  // eslint-disable-next-line no-param-reassign
+  config.queue = [];
+
+  const usp = new URLSearchParams(window.location.search);
+  usp.append('rum', 'on');
+  window.history.replaceState({}, '', `${window.location.pathname}?${usp.toString()}`);
+
+  // eslint-disable-next-line no-param-reassign
+  config.listeners = window.Mocha.process.listeners('uncaughtException');
+  window.Mocha.process.removeAllListeners('uncaughtException');
+  window.Mocha.process.on('uncaughtException', () => {});
+
+  // eslint-disable-next-line no-underscore-dangle
+  navigator._sendBeacon = navigator.sendBeacon;
+  navigator.sendBeacon = (url, d) => {
+    const data = JSON.parse(d);
+    if (data.checkpoint === 'error') {
+      config.queue.push({ url, data });
+    }
+    return true;
+  };
+}
+
+export function after(config) {
+  const usp = new URLSearchParams(window.location.search);
+  usp.delete('rum');
+  window.history.replaceState({}, '', `${window.location.pathname}?${usp.toString()}`);
+  // eslint-disable-next-line no-underscore-dangle
+  window.hlx.rum = undefined;
+
+  const enhancer = document.querySelector('script[src*="rum-enhancer"]');
+  if (enhancer) {
+    enhancer.remove();
+  }
+
+  window.Mocha.process.removeAllListeners('uncaughtException');
+  window.Mocha.process.removeAllListeners('error');
+
+  config.listeners.forEach((lst) => {
+    window.Mocha.process.addListener('uncaughtException', lst);
+  });
+  // eslint-disable-next-line no-param-reassign
+  config.listeners = undefined;
+  // eslint-disable-next-line no-underscore-dangle
+  navigator.sendBeacon = navigator._sendBeacon;
+  // eslint-disable-next-line no-param-reassign, no-unused-vars
+  config.queue = [];
+}

--- a/test/errors/errors.js
+++ b/test/errors/errors.js
@@ -28,7 +28,7 @@ export async function test(errorFct, sourceTest, targetTest, queue) {
   const wait = async () => new Promise((resolve) => {
     window.setTimeout(() => {
       resolve();
-    }, 100);
+    }, 1000);
   });
 
   await wait();

--- a/test/errors/errors.js
+++ b/test/errors/errors.js
@@ -23,7 +23,7 @@ export function fireError() {
 export async function test(errorFct, sourceTest, targetTest, queue) {
   sampleRUM();
 
-  window.setTimeout(errorFct, 1);
+  window.setTimeout(errorFct);
 
   const wait = async () => new Promise((resolve) => {
     window.setTimeout(() => {

--- a/test/errors/sampleRUM.basic.error.custom.test.js
+++ b/test/errors/sampleRUM.basic.error.custom.test.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+
+import { assert, expect } from '@esm-bundle/chai';
+import { test, before, after } from './errors.js';
+
+class MyCustomError extends Error {
+  constructor(message, code) {
+    super(message);
+    this.code = code;
+  }
+}
+
+describe('sampleRUM custom error obj capture', () => {
+  const config = {
+    listeners: null,
+    queue: [],
+  };
+  beforeEach(() => {
+    before(config);
+  });
+
+  afterEach(() => {
+    after(config);
+  });
+
+  it('rum capture simple error', async () => {
+    await test(() => {
+      throw new MyCustomError('This is an unexpected custom error');
+    }, (source) => {
+      expect(source).to.be.a('string');
+      assert.ok(source.match(/sampleRUM.basic.error.custom.test.js/), 'source should contain the file name');
+      assert.ok(source.match(/:40:/), 'source should contain the line number');
+    }, (target) => {
+      expect(target).to.equal('Error: This is an unexpected custom error');
+    }, config.queue);
+  });
+});

--- a/test/errors/sampleRUM.basic.error.custom.test.js
+++ b/test/errors/sampleRUM.basic.error.custom.test.js
@@ -35,7 +35,7 @@ describe('sampleRUM custom error obj capture', () => {
     after(config);
   });
 
-  it('rum capture simple error', async () => {
+  it('rum capture a custom error', async () => {
     await test(() => {
       throw new MyCustomError('This is an unexpected custom error');
     }, (source) => {

--- a/test/errors/sampleRUM.basic.error.custom.test.js
+++ b/test/errors/sampleRUM.basic.error.custom.test.js
@@ -40,8 +40,7 @@ describe('sampleRUM custom error obj capture', () => {
       throw new MyCustomError('This is an unexpected custom error');
     }, (source) => {
       expect(source).to.be.a('string');
-      assert.ok(source.match(/sampleRUM.basic.error.custom.test.js/), 'source should contain the file name');
-      assert.ok(source.match(/:40:/), 'source should contain the line number');
+      assert.ok(source.match(/sampleRUM.basic.error.custom.test.js(.*):[\d]+:/), 'source should contain the file name and line number');
     }, (target) => {
       expect(target).to.equal('Error: This is an unexpected custom error');
     }, config.queue);

--- a/test/errors/sampleRUM.basic.error.test.js
+++ b/test/errors/sampleRUM.basic.error.test.js
@@ -33,8 +33,7 @@ describe('sampleRUM simple error capture', () => {
       throw new Error('This is an unexpected error', { cause: 'root cause' });
     }, (source) => {
       expect(source).to.be.a('string');
-      assert.ok(source.match(/sampleRUM.basic.error.test.js/), 'source should contain the file name');
-      assert.ok(source.match(/:33:/), 'source should contain the line number');
+      assert.ok(source.match(/sampleRUM.basic.error.test.js(.*):[\d]+:/), 'source should contain the file name and line number');
     }, (target) => {
       expect(target).to.equal('Error: This is an unexpected error');
     }, config.queue);

--- a/test/errors/sampleRUM.basic.error.test.js
+++ b/test/errors/sampleRUM.basic.error.test.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+
+import { assert, expect } from '@esm-bundle/chai';
+import { test, before, after } from './errors.js';
+
+describe('sampleRUM simple error capture', () => {
+  const config = {
+    listeners: null,
+    queue: [],
+  };
+  beforeEach(() => {
+    before(config);
+  });
+
+  afterEach(() => {
+    after(config);
+  });
+
+  it('rum capture simple error', async () => {
+    await test(() => {
+      throw new Error('This is an unexpected error', { cause: 'root cause' });
+    }, (source) => {
+      expect(source).to.be.a('string');
+      assert.ok(source.match(/sampleRUM.basic.error.test.js/), 'source should contain the file name');
+      assert.ok(source.match(/:33:/), 'source should contain the line number');
+    }, (target) => {
+      expect(target).to.equal('Error: This is an unexpected error');
+    }, config.queue);
+  });
+});

--- a/test/errors/sampleRUM.real.error.test.js
+++ b/test/errors/sampleRUM.real.error.test.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+
+import { assert, expect } from '@esm-bundle/chai';
+import {
+  test, before, after,
+} from './errors.js';
+
+describe('sampleRUM simple error capture', () => {
+  const config = {
+    listeners: null,
+    queue: [],
+  };
+  beforeEach(() => {
+    before(config);
+  });
+
+  afterEach(() => {
+    after(config);
+  });
+
+  it('rum capture simple error', async () => {
+    await test(() => {
+      let s;
+      s.t = 1;
+    }, (source) => {
+      expect(source).to.be.a('string');
+      assert.ok(source.match(/sampleRUM.real.error.test.js/), 'source should contain the file name');
+      assert.ok(source.match(/:36:/), 'source should contain the line number');
+    }, (target) => {
+      expect(target).to.equal('TypeError: Cannot set properties of undefined (setting \'t\')');
+    }, config.queue);
+  });
+});

--- a/test/errors/sampleRUM.real.error.test.js
+++ b/test/errors/sampleRUM.real.error.test.js
@@ -30,7 +30,7 @@ describe('sampleRUM simple error capture', () => {
     after(config);
   });
 
-  it('rum capture simple error', async () => {
+  it('rum capture implementation error', async () => {
     await test(() => {
       let s;
       s.t = 1;

--- a/test/errors/sampleRUM.real.error.test.js
+++ b/test/errors/sampleRUM.real.error.test.js
@@ -36,10 +36,9 @@ describe('sampleRUM simple error capture', () => {
       s.t = 1;
     }, (source) => {
       expect(source).to.be.a('string');
-      assert.ok(source.match(/sampleRUM.real.error.test.js/), 'source should contain the file name');
-      assert.ok(source.match(/:36:/), 'source should contain the line number');
+      assert.ok(source.match(/sampleRUM.real.error.test.js(.*):[\d]+:/), 'source should contain the file name and line number');
     }, (target) => {
-      expect(target).to.equal('TypeError: Cannot set properties of undefined (setting \'t\')');
+      assert.ok(target.startsWith('TypeError:'));
     }, config.queue);
   });
 });

--- a/test/errors/sampleRUM.real.function.error.test.js
+++ b/test/errors/sampleRUM.real.function.error.test.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+
+import { expect } from '@esm-bundle/chai';
+import {
+  test, before, after, fireError,
+} from './errors.js';
+
+describe('sampleRUM simple error capture', () => {
+  const config = {
+    listeners: null,
+    queue: [],
+  };
+  beforeEach(() => {
+    before(config);
+  });
+
+  afterEach(() => {
+    after(config);
+  });
+
+  it('rum capture simple error', async () => {
+    await test(() => {
+      fireError();
+    }, (source) => {
+      expect(source).to.equal('fireError@http://localhost:8000/test/errors/errors.js:20:7');
+    }, (target) => {
+      expect(target).to.equal('TypeError: Cannot set properties of undefined (setting \'t\')');
+    }, config.queue);
+  });
+});

--- a/test/errors/sampleRUM.real.function.error.test.js
+++ b/test/errors/sampleRUM.real.function.error.test.js
@@ -12,7 +12,7 @@
 
 /* eslint-env mocha */
 
-import { expect } from '@esm-bundle/chai';
+import { assert } from '@esm-bundle/chai';
 import {
   test, before, after, fireError,
 } from './errors.js';
@@ -34,9 +34,9 @@ describe('sampleRUM simple error capture', () => {
     await test(() => {
       fireError();
     }, (source) => {
-      expect(source).to.equal('fireError@http://localhost:8000/test/errors/errors.js:20:7');
+      assert.ok(source.startsWith('fireError@'));
     }, (target) => {
-      expect(target).to.equal('TypeError: Cannot set properties of undefined (setting \'t\')');
+      assert.ok(target.startsWith('TypeError:'));
     }, config.queue);
   });
 });

--- a/test/errors/sampleRUM.real.function.error.test.js
+++ b/test/errors/sampleRUM.real.function.error.test.js
@@ -30,7 +30,7 @@ describe('sampleRUM simple error capture', () => {
     after(config);
   });
 
-  it('rum capture simple error', async () => {
+  it('rum capture implementation error in a module', async () => {
     await test(() => {
       fireError();
     }, (source) => {

--- a/test/errors/sampleRUM.unhandledrejection.noreason.test.js
+++ b/test/errors/sampleRUM.unhandledrejection.noreason.test.js
@@ -29,7 +29,7 @@ describe('sampleRUM simple error capture', () => {
     after(config);
   });
 
-  it('rum capture unhandled promise rejection without reason', async () => {
+  it.only('rum capture unhandled promise rejection without reason', async () => {
     await test(async () => {
       await new Promise((resolve, reject) => {
         // eslint-disable-next-line prefer-promise-reject-errors

--- a/test/errors/sampleRUM.unhandledrejection.noreason.test.js
+++ b/test/errors/sampleRUM.unhandledrejection.noreason.test.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+/* eslint-disable no-unused-expressions */
+
+import { expect } from '@esm-bundle/chai';
+import { test, before, after } from './errors.js';
+
+describe('sampleRUM simple error capture', () => {
+  const config = {
+    listeners: null,
+    queue: [],
+  };
+  beforeEach(() => {
+    before(config);
+  });
+
+  afterEach(() => {
+    after(config);
+  });
+
+  it('rum capture unhandled promise rejection without reason', async () => {
+    await test(async () => {
+      await new Promise((resolve, reject) => {
+        // eslint-disable-next-line prefer-promise-reject-errors
+        reject();
+      });
+    }, (source) => {
+      expect(source).to.equal('Unhandled Rejection');
+    }, (target) => {
+      expect(target).to.equal('Unknown');
+    }, config.queue);
+  });
+});

--- a/test/errors/sampleRUM.unhandledrejection.noreason.test.js
+++ b/test/errors/sampleRUM.unhandledrejection.noreason.test.js
@@ -29,7 +29,7 @@ describe('sampleRUM simple error capture', () => {
     after(config);
   });
 
-  it.only('rum capture unhandled promise rejection without reason', async () => {
+  it('rum capture unhandled promise rejection without reason', async () => {
     await test(async () => {
       await new Promise((resolve, reject) => {
         // eslint-disable-next-line prefer-promise-reject-errors

--- a/test/errors/sampleRUM.unhandledrejection.obj.test.js
+++ b/test/errors/sampleRUM.unhandledrejection.obj.test.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+/* eslint-disable no-unused-expressions */
+
+import { assert, expect } from '@esm-bundle/chai';
+import { test, before, after } from './errors.js';
+
+describe('sampleRUM simple error capture', () => {
+  const config = {
+    listeners: null,
+    queue: [],
+  };
+  beforeEach(() => {
+    before(config);
+  });
+
+  afterEach(() => {
+    after(config);
+  });
+
+  it('rum capture unhandled promise rejection', async () => {
+    await test(async () => {
+      await new Promise((resolve, reject) => {
+        reject(new Error('This is an unhandled promise rejection with error object'));
+      });
+    }, (source) => {
+      expect(source).to.be.a('string');
+      assert.ok(source.match(/sampleRUM.unhandledrejection.obj.test/), 'source should contain the file name');
+      assert.ok(source.match(/:35:/), 'source should contain the line number');
+    }, (target) => {
+      expect(target).to.equal('Error: This is an unhandled promise rejection with error object');
+    }, config.queue);
+  });
+});

--- a/test/errors/sampleRUM.unhandledrejection.obj.test.js
+++ b/test/errors/sampleRUM.unhandledrejection.obj.test.js
@@ -36,8 +36,7 @@ describe('sampleRUM simple error capture', () => {
       });
     }, (source) => {
       expect(source).to.be.a('string');
-      assert.ok(source.match(/sampleRUM.unhandledrejection.obj.test/), 'source should contain the file name');
-      assert.ok(source.match(/:35:/), 'source should contain the line number');
+      assert.ok(source.match(/sampleRUM.unhandledrejection.obj.test.js(.*):[\d]+:/), 'source should contain the file name and line number');
     }, (target) => {
       expect(target).to.equal('Error: This is an unhandled promise rejection with error object');
     }, config.queue);

--- a/test/errors/sampleRUM.unhandledrejection.obj.test.js
+++ b/test/errors/sampleRUM.unhandledrejection.obj.test.js
@@ -29,7 +29,7 @@ describe('sampleRUM simple error capture', () => {
     after(config);
   });
 
-  it('rum capture unhandled promise rejection', async () => {
+  it('rum capture unhandled promise rejection where reason is an error object', async () => {
     await test(async () => {
       await new Promise((resolve, reject) => {
         reject(new Error('This is an unhandled promise rejection with error object'));

--- a/test/errors/sampleRUM.unhandledrejection.test.js
+++ b/test/errors/sampleRUM.unhandledrejection.test.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+/* eslint-disable no-unused-expressions */
+
+import { expect } from '@esm-bundle/chai';
+import { test, before, after } from './errors.js';
+
+describe('sampleRUM simple error capture', () => {
+  const config = {
+    listeners: null,
+    queue: [],
+  };
+  beforeEach(() => {
+    before(config);
+  });
+
+  afterEach(() => {
+    after(config);
+  });
+
+  it('rum capture unhandled promise rejection', async () => {
+    await test(async () => {
+      await new Promise((resolve, reject) => {
+        // eslint-disable-next-line prefer-promise-reject-errors
+        reject('This is an unhandled promise rejection');
+      });
+    }, (source) => {
+      expect(source).to.equal('Unhandled Rejection');
+    }, (target) => {
+      expect(target).to.equal('This is an unhandled promise rejection');
+    }, config.queue);
+  });
+});

--- a/test/sampleRUM-error.test.js
+++ b/test/sampleRUM-error.test.js
@@ -36,45 +36,6 @@ describe('sampleRUM', () => {
     }
   });
 
-  it('rum error selected', () => {
-    const listeners = window.Mocha.process.listeners('uncaughtException');
-    window.Mocha.process.removeAllListeners('uncaughtException');
-    window.Mocha.process.on('uncaughtException', () => {
-      // console.log('Expected uncaught Exception ', err);
-    });
-    // eslint-disable-next-line no-underscore-dangle
-    navigator._sendBeacon = navigator.sendBeacon;
-    navigator.sendBeacon = (url, data) => {
-      if (data && JSON.parse(data).checkpoint === 'top') {
-        try {
-          throw new Error('Expected error');
-        } catch (error) {
-          window.dispatchEvent(
-            new ErrorEvent(
-              'error',
-              {
-                error,
-                message: 'Force error to test error handler!',
-                lineno: 999,
-                filename: 'sampleRUM.test.js',
-                cancelable: true,
-              },
-            ),
-          );
-        }
-      }
-      return true;
-    };
-    sampleRUM();
-    expect(window.hlx.rum.queue.length).to.equal(1);
-    expect(window.hlx.rum.queue.pop()[0]).to.equal('error');
-    // eslint-disable-next-line no-underscore-dangle
-    navigator.sendBeacon = navigator._sendBeacon;
-    listeners.forEach((lst) => {
-      window.Mocha.process.addListener('uncaughtException', lst);
-    });
-  });
-
   it('rum capture exception', () => {
     sampleRUM();
     window.hlx.rum.queue = undefined;


### PR DESCRIPTION
While looking at the error tracking, I realized there are some inconsistencies like:
- if error occur in the HTML file, the source appears as ` at https://...` while if error occurs in a JS file it shows `functionname@https://...` - addressed by the PR
- we have a lot of `source: undefined error` (and no target) - while this might be the case for unhandled promise rejections, code could try to identify a better source and target for those cases.

I also wrote tests to cover all different scenarii.
