### PR TITLE
fix: add missing license to packaged code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adobe/helix-rum-js",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/helix-rum-js",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@adobe/eslint-config-helix": "2.0.6",
@@ -31,6 +31,7 @@
         "mocha-multi-reporters": "1.5.1",
         "rollup": "4.20.0",
         "rollup-plugin-cleanup": "3.2.1",
+        "rollup-plugin-eslint-bundle": "9.0.0",
         "semantic-release": "24.1.0"
       }
     },
@@ -13479,6 +13480,38 @@
         "rollup": ">=2.0"
       }
     },
+    "node_modules/rollup-plugin-eslint-bundle": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-eslint-bundle/-/rollup-plugin-eslint-bundle-9.0.0.tgz",
+      "integrity": "sha512-BqsZINY0pKzvgwngj2lCqMBf12m5veHKP6gOKm9VE8Ki2IA1Jz+K64Nh18T+UQCuEwSl35wjp6PfF1ovNxnYMw==",
+      "dev": true,
+      "dependencies": {
+        "diff": "^5.1.0",
+        "magic-string": "^0.30.5"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.x",
+        "rollup": "4.x"
+      }
+    },
+    "node_modules/rollup-plugin-eslint-bundle/node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "dev": true
+    },
+    "node_modules/rollup-plugin-eslint-bundle/node_modules/magic-string": {
+      "version": "0.30.11",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.11.tgz",
+      "integrity": "sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
     "node_modules/rollup-pluginutils": {
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
@@ -25624,6 +25657,33 @@
       "requires": {
         "js-cleanup": "^1.2.0",
         "rollup-pluginutils": "^2.8.2"
+      }
+    },
+    "rollup-plugin-eslint-bundle": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-eslint-bundle/-/rollup-plugin-eslint-bundle-9.0.0.tgz",
+      "integrity": "sha512-BqsZINY0pKzvgwngj2lCqMBf12m5veHKP6gOKm9VE8Ki2IA1Jz+K64Nh18T+UQCuEwSl35wjp6PfF1ovNxnYMw==",
+      "dev": true,
+      "requires": {
+        "diff": "^5.1.0",
+        "magic-string": "^0.30.5"
+      },
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+          "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+          "dev": true
+        },
+        "magic-string": {
+          "version": "0.30.11",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.11.tgz",
+          "integrity": "sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/sourcemap-codec": "^1.5.0"
+          }
+        }
       }
     },
     "rollup-pluginutils": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "mocha-multi-reporters": "1.5.1",
     "rollup": "4.20.0",
     "rollup-plugin-cleanup": "3.2.1",
+    "rollup-plugin-eslint-bundle": "9.0.0",
     "semantic-release": "24.1.0"
   },
   "lint-staged": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,18 +11,19 @@
  */
 
 import cleanup from 'rollup-plugin-cleanup';
+import eslint from 'rollup-plugin-eslint-bundle';
 
-// const banner = `/*
-//  * Copyright 2024 Adobe. All rights reserved.
-//  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
-//  * you may not use this file except in compliance with the License. You may obtain a copy
-//  * of the License at http://www.apache.org/licenses/LICENSE-2.0
-//  *
-//  * Unless required by applicable law or agreed to in writing, software distributed under
-//  * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-//  * OF ANY KIND, either express or implied. See the License for the specific language
-//  * governing permissions and limitations under the License.
-//  */
+const banner = `/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
 
 // /* eslint-disable max-classes-per-file */`;
 
@@ -45,12 +46,18 @@ export default [...bundles.map(({ outputFile, source }) => ({
       format: 'iife',
       sourcemap: false,
       exports: 'auto',
+      banner,
     },
   ].filter((m) => m),
   plugins: [
     cleanup({
       comments: ['eslint', 'jsdoc', /^\//, /^\*(?!\sc8\s)(?!\n \* Copyright)/],
       maxEmptyLines: -1,
+    }),
+    eslint({
+      eslintOptions: {
+        fix: true,
+      },
     }),
   ],
 }))];


### PR DESCRIPTION
Adds the license to `rum-standalone.js` and `rum-standalone-404.js`.