### PR TITLE
docs(api): point out this is a private API

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1,7 +1,8 @@
 <a name="sampleRUM"></a>
 
 ## sampleRUM(checkpoint, data)
-log RUM if part of the sample.
+log RUM if part of the sample. This is an internal API and should not be called directly by projects. The collection service validates and rejects
+samples with unknown `checkpoint` values and implausible `source` and `target` value.
 
 **Kind**: global function  
 


### PR DESCRIPTION
Carsten's comment in #208 mentioned that the docs imply that you should call this API directly. You should not.

