### PR TITLE
feat(enhancer-version): allow selecting a specific enhancer version in standalone

### DIFF
--- a/src/404.js
+++ b/src/404.js
@@ -14,8 +14,10 @@ import { sampleRUM } from './index.js';
 try {
   const scriptSrc = (document.currentScript && document.currentScript.src)
     ? new URL(document.currentScript.src, window.location.origin).origin : null;
-  const scriptParams = (document.currentScript && document.currentScript.dataset)
-    ? document.currentScript.dataset : null;
+  // eslint-disable-next-line max-len
+  const dataAttrs = (document.currentScript && document.currentScript.dataset) ? document.currentScript.dataset : {};
+  const { enhancerVersion, enhancerHash, ...scriptParams } = dataAttrs;
+  sampleRUM.enhancerContext = { enhancerVersion, enhancerHash };
   window.RUM_BASE = window.RUM_BASE || scriptSrc;
   window.RUM_PARAMS = window.RUM_PARAMS || scriptParams;
   sampleRUM('404', { source: document.referrer });

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ export function sampleRUM(checkpoint, data) {
   const timeShift = () => (window.performance ? window.performance.now() : Date.now() - window.hlx.rum.firstReadTime);
   try {
     window.hlx = window.hlx || {};
-    sampleRUM.enhance = () => { };
+    sampleRUM.enhance = () => {};
     if (!window.hlx.rum) {
       const param = new URLSearchParams(window.location.search).get('rum');
       const weight = (window.SAMPLE_PAGEVIEWS_AT_RATE === 'high' && 10)

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ export function sampleRUM(checkpoint, data) {
   const timeShift = () => (window.performance ? window.performance.now() : Date.now() - window.hlx.rum.firstReadTime);
   try {
     window.hlx = window.hlx || {};
-    sampleRUM.enhance = () => {};
+    sampleRUM.enhance = () => { };
     if (!window.hlx.rum) {
       const param = new URLSearchParams(window.location.search).get('rum');
       const weight = (window.SAMPLE_PAGEVIEWS_AT_RATE === 'high' && 10)
@@ -73,9 +73,13 @@ export function sampleRUM(checkpoint, data) {
         sampleRUM.enhance = () => {
           // only enhance once
           if (document.querySelector('script[src*="rum-enhancer"]')) return;
-
+          const { enhancerVersion, enhancerHash } = sampleRUM.enhancerContext || {};
           const script = document.createElement('script');
-          script.src = new URL('.rum/@adobe/helix-rum-enhancer@^2/src/index.js', sampleRUM.baseURL).href;
+          if (enhancerHash) {
+            script.integrity = enhancerHash;
+            script.setAttribute('crossorigin', 'anonymous');
+          }
+          script.src = new URL(`.rum/@adobe/helix-rum-enhancer@${enhancerVersion || '^2'}/src/index.js`, sampleRUM.baseURL).href;
           document.head.appendChild(script);
         };
         if (!window.hlx.RUM_MANUAL_ENHANCE) {

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -14,8 +14,10 @@ import { sampleRUM } from './index.js';
 try {
   const scriptSrc = (document.currentScript && document.currentScript.src)
     ? new URL(document.currentScript.src, window.location.origin).origin : null;
-  const scriptParams = (document.currentScript && document.currentScript.dataset)
-    ? document.currentScript.dataset : null;
+  // eslint-disable-next-line max-len
+  const dataAttrs = (document.currentScript && document.currentScript.dataset) ? document.currentScript.dataset : {};
+  const { enhancerVersion, enhancerHash, ...scriptParams } = dataAttrs;
+  sampleRUM.enhancerContext = { enhancerVersion, enhancerHash };
   window.RUM_BASE = window.RUM_BASE || scriptSrc;
   window.RUM_PARAMS = window.RUM_PARAMS || scriptParams;
 

--- a/test/sampleRUM-with-enhancer-version.test.html
+++ b/test/sampleRUM-with-enhancer-version.test.html
@@ -1,0 +1,52 @@
+<html>
+
+<head>
+  <script>
+    window.RUM_PARAMS = { program: 'pXXXXXX', environment: 'eYYYYYY'};
+    const usp = new URLSearchParams(window.location.search);
+    usp.append('rum', 'on');
+    window.history.replaceState({}, '', `${window.location.pathname}?${usp.toString()}`);
+    window.sendBeaconArgs = {};
+    // eslint-disable-next-line no-underscore-dangle
+    navigator._sendBeacon = navigator.sendBeacon;
+    navigator.sendBeacon = (url, data) => {
+      sendBeaconArgs.url = url;
+      sendBeaconArgs.data = JSON.parse(data);
+      return true;
+    };
+  </script>
+  <script type="module">
+    import { sampleRUM } from '../src/index.js';
+    sampleRUM.enhancerContext = { enhancerVersion: 'X.Y.Z', enhancerHash: '123456789ABC' };
+    // early call to sampleRUM, i.e. before load event
+    sampleRUM();
+  </script>
+</head>
+
+<body>
+  <script type="module">
+    import { runTests } from '@web/test-runner-mocha';
+    import { expect } from '@esm-bundle/chai';
+    /* eslint-env mocha */
+    runTests(async () => {
+      describe('sampleRUM - enhancer context', () => {
+        it('rum enhancerVersion', async () => {
+          const enhancerScript = document.querySelector('script[src*="rum-enhancer"]');
+          expect(enhancerScript).to.exist;
+          const enhancerUrlPath = new URL(enhancerScript.src).pathname;
+          expect(enhancerUrlPath).to.equal('/.rum/@adobe/helix-rum-enhancer@X.Y.Z/src/index.js');
+          expect(enhancerScript.getAttribute('crossorigin')).to.equal('anonymous');
+          expect(enhancerScript.integrity).to.equal('123456789ABC');
+        });
+        it('rum enhancer integrity', async () => {
+          const enhancerScript = document.querySelector('script[src*="rum-enhancer"]');
+          expect(enhancerScript).to.exist;
+          expect(enhancerScript.getAttribute('crossorigin')).to.equal('anonymous');
+          expect(enhancerScript.integrity).to.equal('123456789ABC');
+        });
+      });
+    });
+  </script>
+</body>
+
+</html>


### PR DESCRIPTION
Fixes: #203 

Allow users of standalone distribution to provide a specific enhancer version, and a md5 hash 
