### PR TITLE
feat: allow to enhance only once

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -71,6 +71,9 @@ export function sampleRUM(checkpoint, data) {
         sampleRUM.sendPing('top', timeShift());
 
         sampleRUM.enhance = () => {
+          // only enhance once
+          if (document.querySelector('script[src*="rum-enhancer"]')) return;
+
           const script = document.createElement('script');
           script.src = new URL('.rum/@adobe/helix-rum-enhancer@^2/src/index.js', sampleRUM.baseURL).href;
           document.head.appendChild(script);

--- a/test/loading/enhance-manual-late.test.html
+++ b/test/loading/enhance-manual-late.test.html
@@ -25,6 +25,10 @@
             expect(document.querySelector('script[src*="rum-enhancer"]')).to.not.exist;
             sampleRUM.enhance();
             expect(document.querySelector('script[src*="rum-enhancer"]')).to.exist;
+            // test enhance once
+            sampleRUM.enhance();
+            const scripts = document.querySelectorAll('script[src*="rum-enhancer"]');
+            expect(scripts.length).to.equal(1);
           });
         });
       });


### PR DESCRIPTION
If `sampleRUM.enhance()` is called twice, enhancer code will be injected twice and we might have duplicate events.