### PR TITLE
Use Performance API to get response status and sample accordingly

### DIFF
--- a/src/standalone.js
+++ b/src/standalone.js
@@ -21,7 +21,27 @@ try {
   window.RUM_BASE = window.RUM_BASE || scriptSrc;
   window.RUM_PARAMS = window.RUM_PARAMS || scriptParams;
 
-  sampleRUM();
+  let status;
+  if (window.performance && window.performance.getEntriesByType) {
+    for (const { name, responseStatus, serverTiming } of window.performance.getEntriesByType("navigation")) {
+      if (name === window.location.href) {
+        status = responseStatus;
+      }
+      if (!status && serverTiming) {
+        for (const {name, duration} of serverTiming) {
+          if (name === "status") {
+            status = duration;
+          }
+        }
+      }
+    }
+  }
+
+  if (status && status === 404) {
+    sampleRUM('404', { source: document.referrer });
+  } else {
+    sampleRUM();
+  }
 } catch (error) {
   // something went wrong
 }


### PR DESCRIPTION
In cloud service depending on configuration we may not know the actual response status when injecting the RUM script, thus cannot determine if the 404 or standalone script should be included. This PR adds client-side code to determine the response status using the Performance API and trigger the 404 sampling when needed, effectively combining the 404 and standalone script into one.

The response code is read from the [PerformanceNavigationTiming](https://www.w3.org/TR/navigation-timing-2/#dom-performancenavigationtiming) object. The `responseStatus` is supported by modern browsers except for Safari. As a fallback the ServerTiming object is inspected for a `status` property which is read from a `server-timing` header which needs to be injected by the server, e.g. in the CDN. This is also supported by Safari.