### PR TITLE
feat(standalone): Use data attribute for 404 tracking (avoid separate script)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ To do it, simply add the following script to your pages.
 <script defer type="text/javascript" src="https://rum.hlx.page/.rum/@adobe/helix-rum-js@^2/dist/rum-standalone.js"></script>
 ```
 
-If you want to instruct a 404 response, include this script instead in standalone mode.
+If you want to instruct a 404 response, include the same script but set the status data attribute to 404.
 ```html
-<script defer type="text/javascript" src="https://rum.hlx.page/.rum/@adobe/helix-rum-js@^2/dist/rum-standalone-404.js"></script>
+<script defer type="text/javascript" src="https://rum.hlx.page/.rum/@adobe/helix-rum-js@^2/dist/rum-standalone.js" data-status="404"></script>
 ```
 
 If you understand the details of a high performance page, it might be advisable to load the script after the [LCP](https://web.dev/articles/lcp) event

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -16,14 +16,16 @@ try {
     ? new URL(document.currentScript.src, window.location.origin).origin : null;
   // eslint-disable-next-line max-len
   const dataAttrs = (document.currentScript && document.currentScript.dataset) ? document.currentScript.dataset : {};
-  const { enhancerVersion, enhancerHash, ...scriptParams } = dataAttrs;
+  const {
+    status, enhancerVersion, enhancerHash, ...scriptParams
+  } = dataAttrs;
   sampleRUM.enhancerContext = { enhancerVersion, enhancerHash };
   window.RUM_BASE = window.RUM_BASE || scriptSrc;
   window.RUM_PARAMS = window.RUM_PARAMS || scriptParams;
 
   const [navigation] = (window.performance && window.performance.getEntriesByType('navigation')) || [];
-  const is404 = navigation && navigation.name === window.location.href
-    && navigation.responseStatus === 404;
+  const is404 = status === '404' || (navigation && navigation.name === window.location.href
+    && navigation.responseStatus === 404);
 
   if (is404) {
     sampleRUM('404', { source: document.referrer });


### PR DESCRIPTION
Currently we create two scripts standalone and standalone-404 - which are mainly identical, with the exception that the latter is used for tracking 404 responses. With the recent introduction of using the navigation API into the standalone script, it makes sense to merge the functionality into a single script.

This patch uses the data-status attribute to inform the script of a 404 response, instead of using a separate script.

For now we should still create the standalone-404 until we can phase it out