### PR TITLE
chore(renovate): renovate PRs on dev dependencies do not trigger psi check

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,3 +1,10 @@
 {
-  "extends": ["github>adobe/helix-shared"]
+  "extends": ["github>adobe/helix-shared"],
+  "packageRules": [
+    {
+      "matchDepTypes": ["devDependencies"],
+      "label": "ignore-psi-check", 
+      "automerge": true
+    }
+  ]
 }


### PR DESCRIPTION
Use new helix-bot capability (see https://github.com/adobe/helix-bot/issues/1573) to ignore psi check if renovate makes a PR on dev dependency.