### PR TITLE
fix: increase browserStartTimeout for Firefox to 120s in CI tests

### DIFF
--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -10,14 +10,8 @@
  * governing permissions and limitations under the License.
  */
 export default {
-  browserStartTimeout: 60000, // Default timeout for Chrome and WebKit
-  browsers: [
-    {
-      name: 'firefox',
-      // Increase timeout specifically for Firefox as it's taking longer in CI
-      browserStartTimeout: 120000,
-    },
-  ],
+  // Increase browserStartTimeout to fix Firefox timeout issues in CI
+  browserStartTimeout: 120000,
   coverageConfig: {
     report: true,
     reportDir: 'coverage',

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -10,7 +10,14 @@
  * governing permissions and limitations under the License.
  */
 export default {
-  browserStartTimeout: 60000,
+  browserStartTimeout: 60000, // Default timeout for Chrome and WebKit
+  browsers: [
+    {
+      name: 'firefox',
+      // Increase timeout specifically for Firefox as it's taking longer in CI
+      browserStartTimeout: 120000,
+    },
+  ],
   coverageConfig: {
     report: true,
     reportDir: 'coverage',


### PR DESCRIPTION
This PR increases the browserStartTimeout for Firefox browsers to 120 seconds (from the default 60 seconds) to fix failing tests in CI environments. Both PR #243 and PR #244 have been failing with Firefox timeouts during test initialization, and this change should resolve that issue.