### PR TITLE
chore: disable tests on Firefox

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "src/index.js",
   "type": "module",
   "scripts": {
-    "setup-playwright": "npx playwright install --with-deps chromium firefox webkit",
-    "test": "npm run setup-playwright && web-test-runner --node-resolve --coverage --playwright --browsers chromium firefox webkit",
-    "test-ci": "npm run setup-playwright && web-test-runner --node-resolve --coverage --playwright --browsers chromium firefox webkit",
+    "setup-playwright": "npx playwright install --with-deps chromium webkit",
+    "test": "npm run setup-playwright && web-test-runner --node-resolve --coverage --playwright --browsers chromium webkit",
+    "test-ci": "npm run setup-playwright && web-test-runner --node-resolve --coverage --playwright --browsers chromium webkit",
     "test:watch": "web-test-runner --node-resolve --watch --coverage",
     "build-standalone": "rollup --config",
     "prepack": "npm run build-standalone",

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 export default {
-  // Increase browserStartTimeout to fix Firefox timeout issues in CI
-  browserStartTimeout: 120000,
   coverageConfig: {
     report: true,
     reportDir: 'coverage',


### PR DESCRIPTION
Currently tests execution on Firefox is not properly working because Firefox does not start as expected.
I have created https://github.com/microsoft/playwright/issues/35183 and https://github.com/modernweb-dev/web/issues/2907.
In the meantime, I suggest to remove Firefox for the browser list and to create an issue to keep track to re-enable it when the bugs are fixed.