### PR TITLE
ci(github): release changes to github, in dedicated release branches, so that they can be synced to code bus

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -38,7 +38,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          persist-credentials: false
+          persist-credentials: true
+          token: ${{ secrets.ADOBE_BOT_GITHUB_TOKEN }}
       - name: Use Node.js 20
         uses: actions/setup-node@v4
         with:

--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -6,6 +6,9 @@ module.exports = {
       "changelogFile": "CHANGELOG.md",
     }],
     "@semantic-release/npm",
+    ["@semantic-release/exec", {
+      "publishCmd": "./tagger.sh ${nextRelease.version} --push"
+    }],
     ["@semantic-release/git", {
       "assets": [
         "package.json",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "@adobe/helix-rum-js",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/helix-rum-js",
-      "version": "2.10.1",
+      "version": "2.10.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@adobe/eslint-config-helix": "2.0.9",
         "@esm-bundle/chai": "4.3.4-fix.0",
         "@playwright/test": "1.51.1",
         "@semantic-release/changelog": "6.0.3",
+        "@semantic-release/exec": "^7.0.3",
         "@semantic-release/git": "10.0.1",
         "@semantic-release/npm": "12.0.1",
         "@web/test-runner": "0.20.0",
@@ -66,13 +67,15 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
-      "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
+      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/highlight": "^7.23.4",
-        "chalk": "^2.4.2"
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -92,20 +95,6 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
       "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
       "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight": {
-      "version": "7.23.4",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
-      "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.22.20",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1343,6 +1332,259 @@
       "dev": true,
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/@semantic-release/exec": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@semantic-release/exec/-/exec-7.0.3.tgz",
+      "integrity": "sha512-uNWwPNtWi3WTcTm3fWfFQEuj8otOvwoS5m9yo2jSVHuvqdZNsOWmuL0/FqcVyZnCI32fxyYV0G7PPb/TzCH6jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@semantic-release/error": "^4.0.0",
+        "aggregate-error": "^3.0.0",
+        "debug": "^4.0.0",
+        "execa": "^9.0.0",
+        "lodash-es": "^4.17.21",
+        "parse-json": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20.8.1"
+      },
+      "peerDependencies": {
+        "semantic-release": ">=24.1.0"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/@semantic-release/error": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
+      "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/execa": {
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.5.2.tgz",
+      "integrity": "sha512-EHlpxMCpHWSAh1dgS6bVeoLAXGnJNdR93aabr4QCGbzOM73o5XmRfM/e5FUqsw3aagP8S8XEWUWFAxnRBnAF0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.3",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.0",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/index-to-position": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.1.0.tgz",
+      "integrity": "sha512-XPdx9Dq4t9Qk1mTMbWONJqU7boCoumEH7fRET37HX5+khDUl3J2W6PdALxhILYlIYx2amlwYcRPp28p0tSiojg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/parse-json": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+      "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "index-to-position": "^1.1.0",
+        "type-fest": "^4.39.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/type-fest": {
+      "version": "4.39.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.39.1.tgz",
+      "integrity": "sha512-uW9qzd66uyHYxwyVBYiwS4Oi0qZyUqwjU+Oevr6ZogYiXt99EOYtwvzMSLw1c3lYo2HzJsep/NB23iEVEgjG/w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@semantic-release/git": {
@@ -7589,7 +7831,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "3.14.1",
@@ -13085,6 +13328,13 @@
         "node": ">=6.14"
       }
     },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -16576,13 +16826,14 @@
       }
     },
     "@babel/code-frame": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
-      "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
+      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.23.4",
-        "chalk": "^2.4.2"
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
       }
     },
     "@babel/helper-string-parser": {
@@ -16596,17 +16847,6 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
       "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
       "dev": true
-    },
-    "@babel/highlight": {
-      "version": "7.23.4",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
-      "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-validator-identifier": "^7.22.20",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0"
-      }
     },
     "@babel/parser": {
       "version": "7.26.1",
@@ -17466,6 +17706,148 @@
       "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
       "integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
       "dev": true
+    },
+    "@semantic-release/exec": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@semantic-release/exec/-/exec-7.0.3.tgz",
+      "integrity": "sha512-uNWwPNtWi3WTcTm3fWfFQEuj8otOvwoS5m9yo2jSVHuvqdZNsOWmuL0/FqcVyZnCI32fxyYV0G7PPb/TzCH6jw==",
+      "dev": true,
+      "requires": {
+        "@semantic-release/error": "^4.0.0",
+        "aggregate-error": "^3.0.0",
+        "debug": "^4.0.0",
+        "execa": "^9.0.0",
+        "lodash-es": "^4.17.21",
+        "parse-json": "^8.0.0"
+      },
+      "dependencies": {
+        "@semantic-release/error": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
+          "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
+          "dev": true
+        },
+        "@sindresorhus/merge-streams": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+          "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+          "dev": true
+        },
+        "execa": {
+          "version": "9.5.2",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-9.5.2.tgz",
+          "integrity": "sha512-EHlpxMCpHWSAh1dgS6bVeoLAXGnJNdR93aabr4QCGbzOM73o5XmRfM/e5FUqsw3aagP8S8XEWUWFAxnRBnAF0Q==",
+          "dev": true,
+          "requires": {
+            "@sindresorhus/merge-streams": "^4.0.0",
+            "cross-spawn": "^7.0.3",
+            "figures": "^6.1.0",
+            "get-stream": "^9.0.0",
+            "human-signals": "^8.0.0",
+            "is-plain-obj": "^4.1.0",
+            "is-stream": "^4.0.1",
+            "npm-run-path": "^6.0.0",
+            "pretty-ms": "^9.0.0",
+            "signal-exit": "^4.1.0",
+            "strip-final-newline": "^4.0.0",
+            "yoctocolors": "^2.0.0"
+          }
+        },
+        "figures": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+          "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+          "dev": true,
+          "requires": {
+            "is-unicode-supported": "^2.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+          "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+          "dev": true,
+          "requires": {
+            "@sec-ant/readable-stream": "^0.4.1",
+            "is-stream": "^4.0.1"
+          }
+        },
+        "human-signals": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+          "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+          "dev": true
+        },
+        "index-to-position": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.1.0.tgz",
+          "integrity": "sha512-XPdx9Dq4t9Qk1mTMbWONJqU7boCoumEH7fRET37HX5+khDUl3J2W6PdALxhILYlIYx2amlwYcRPp28p0tSiojg==",
+          "dev": true
+        },
+        "is-stream": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+          "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+          "dev": true
+        },
+        "is-unicode-supported": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+          "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+          "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+          "dev": true,
+          "requires": {
+            "path-key": "^4.0.0",
+            "unicorn-magic": "^0.3.0"
+          }
+        },
+        "parse-json": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+          "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.26.2",
+            "index-to-position": "^1.1.0",
+            "type-fest": "^4.39.1"
+          }
+        },
+        "path-key": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+          "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+          "dev": true
+        },
+        "signal-exit": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+          "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+          "dev": true
+        },
+        "strip-final-newline": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+          "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+          "dev": true
+        },
+        "type-fest": {
+          "version": "4.39.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.39.1.tgz",
+          "integrity": "sha512-uW9qzd66uyHYxwyVBYiwS4Oi0qZyUqwjU+Oevr6ZogYiXt99EOYtwvzMSLw1c3lYo2HzJsep/NB23iEVEgjG/w==",
+          "dev": true
+        },
+        "unicorn-magic": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+          "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+          "dev": true
+        }
+      }
     },
     "@semantic-release/git": {
       "version": "10.0.1",
@@ -25923,6 +26305,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/perf-regexes/-/perf-regexes-1.0.1.tgz",
       "integrity": "sha512-L7MXxUDtqr4PUaLFCDCXBfGV/6KLIuSEccizDI7JxT+c9x1G1v04BQ4+4oag84SHaCdrBgQAIs/Cqn+flwFPng==",
+      "dev": true
+    },
+    "picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true
     },
     "picomatch": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@esm-bundle/chai": "4.3.4-fix.0",
     "@playwright/test": "1.51.1",
     "@semantic-release/changelog": "6.0.3",
+    "@semantic-release/exec": "7.0.3",
     "@semantic-release/git": "10.0.1",
     "@semantic-release/npm": "12.0.1",
     "@web/test-runner": "0.20.0",

--- a/tagger.sh
+++ b/tagger.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+
+# Check if at least one argument is provided
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <version> [paths...] [--push]"
+  echo "Example: $0 2.3.4 path/to/dir1 path/to/file2 --push"
+  exit 1
+fi
+
+# Extract version number (first argument)
+VERSION=$1
+shift
+
+# Initialize variables
+PUSH=false
+PATHS=()
+
+# Process remaining arguments
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --push)
+      PUSH=true
+      echo "Push flag enabled: branches will be force-pushed to origin"
+      ;;
+    *)
+      PATHS+=("$1")
+      ;;
+  esac
+  shift
+done
+
+# Configure branch prefix
+PREFIX="release"
+
+# Convert version to branch name by replacing non-alphanumeric chars with dashes
+EXACT_BRANCH_NAME="${PREFIX}-$(echo $VERSION | sed 's/[^[:alnum:]]/-/g')"
+
+# Check if version is a pure semver without suffixes (like 2.3.4 without -rc1 etc.)
+if [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  # Extract major, minor, and patch components
+  MAJOR=$(echo $VERSION | cut -d. -f1)
+  MINOR=$(echo $VERSION | cut -d. -f2)
+  PATCH=$(echo $VERSION | cut -d. -f3)
+  
+  # Create specialized branch names
+  PATCH_BRANCH_NAME="${PREFIX}-${MAJOR}-${MINOR}-${PATCH}"
+  MINOR_BRANCH_NAME="${PREFIX}-${MAJOR}-${MINOR}-x"
+  MAJOR_BRANCH_NAME="${PREFIX}-${MAJOR}-x"
+else
+  # For versions with suffixes, these specialized branches aren't created
+  PATCH_BRANCH_NAME=""
+  MINOR_BRANCH_NAME=""
+  MAJOR_BRANCH_NAME=""
+fi
+
+# Output extracted parameters
+echo "Version: $VERSION"
+echo "Exact branch name: $EXACT_BRANCH_NAME"
+if [[ -n $PATCH_BRANCH_NAME ]]; then
+  echo "Patch branch name: $PATCH_BRANCH_NAME"
+  echo "Minor branch name: $MINOR_BRANCH_NAME"
+  echo "Major branch name: $MAJOR_BRANCH_NAME"
+fi
+echo "Push flag: $PUSH"
+echo "Number of paths: ${#PATHS[@]}"
+if [ ${#PATHS[@]} -gt 0 ]; then
+  echo "Paths:"
+  for path in "${PATHS[@]}"; do
+    echo "  - $path"
+  done
+fi
+
+# Store the current branch name
+CURRENT_BRANCH=$(git branch --show-current)
+
+# Validate that we have files to add
+if [ ${#PATHS[@]} -eq 0 ]; then
+  echo "Error: No files specified to add."
+  exit 1
+fi
+
+# Create a temporary directory to store copies of the files
+TEMP_DIR=$(mktemp -d)
+echo "Creating temporary copies of files at $TEMP_DIR"
+
+# Copy all specified files to the temporary directory
+for path in "${PATHS[@]}"; do
+  # Create directory structure in temp dir
+  mkdir -p "$TEMP_DIR/$(dirname "$path")"
+  # Copy the file
+  cp "$path" "$TEMP_DIR/$path"
+  echo "Copied $path to $TEMP_DIR/$path"
+done
+
+# Create commit message
+COMMIT_MSG="Update for version $VERSION"
+
+# Function to create or update a branch and commit changes
+create_or_update_branch() {
+  local branch_name=$1
+  
+  echo "Processing branch: $branch_name"
+  
+  # Check if branch exists
+  if git show-ref --verify --quiet refs/heads/$branch_name; then
+    # Branch exists, reset it from main
+    echo "Branch $branch_name exists, resetting from main..."
+    git checkout main
+    git branch -D $branch_name
+    git checkout -b $branch_name
+  else
+    # Create new branch from main
+    echo "Creating new branch $branch_name from main..."
+    git checkout main
+    git checkout -b $branch_name
+  fi
+  
+  # Copy files from temp directory back to working directory
+  for path in "${PATHS[@]}"; do
+    # Create directory structure if needed
+    mkdir -p "$(dirname "$path")"
+    # Copy the file back from temp
+    cp "$TEMP_DIR/$path" "$path"
+    echo "Restored $path from $TEMP_DIR/$path"
+  done
+  
+  # Add files to git, even if they're in .gitignore
+  echo "Adding files to git staging area in branch $branch_name..."
+  for path in "${PATHS[@]}"; do
+    git add --force "$path"
+  done
+  
+  # Commit changes
+  git commit -m "$COMMIT_MSG"
+  
+  # Push if requested
+  if [ "$PUSH" = true ]; then
+    echo "Force-pushing branch $branch_name to origin..."
+    git push -f origin $branch_name
+    echo "Successfully pushed $branch_name to origin."
+  fi
+}
+
+# Process each branch
+echo "Creating/updating branches and committing changes..."
+
+# Always process the exact branch
+create_or_update_branch $EXACT_BRANCH_NAME
+
+# Process other branches if they exist
+if [[ -n $PATCH_BRANCH_NAME ]]; then
+  create_or_update_branch $PATCH_BRANCH_NAME
+  create_or_update_branch $MINOR_BRANCH_NAME
+  create_or_update_branch $MAJOR_BRANCH_NAME
+fi
+
+# Clean up temporary directory
+echo "Cleaning up temporary files..."
+rm -rf "$TEMP_DIR"
+
+# Return to the original branch
+echo "Returning to original branch: $CURRENT_BRANCH"
+git checkout $CURRENT_BRANCH
+
+if [ "$PUSH" = true ]; then
+  echo "All branches have been force-pushed to origin."
+fi
+
+echo "Done!"


### PR DESCRIPTION
this is a step towards using helix as a backend for script delivery instead of unpkg or jsdelivr.
for each release, we create or update three branches:
release-2-34-3 for the exact version number
release-2-34-x for the minor version
release-2-x for the major version

once this has been merged, and once the helix bot has been activated for the repo again, we will be able to use helix as the backend for newer versions in helix-rum-collector
