### PR TITLE
chore: get rid of Math.random for id generation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ export function sampleRUM(checkpoint, data) {
         || (window.SAMPLE_PAGEVIEWS_AT_RATE === 'high' && 10)
         || (window.SAMPLE_PAGEVIEWS_AT_RATE === 'low' && 1000)
         || 100;
-      const id = Math.random().toString(36).slice(-4);
+      const id = crypto.getRandomValues(new Uint32Array(1))[0].toString(36).slice(-4);
       const isSelected = (param !== 'off') && (Math.random() * weight < 1);
       // eslint-disable-next-line object-curly-newline, max-len
       window.hlx.rum = { weight, id, isSelected, firstReadTime: window.performance ? window.performance.timeOrigin : Date.now(), sampleRUM, queue: [], collector: (...args) => window.hlx.rum.queue.push(args) };

--- a/test/sampleRUM-enabled.test.js
+++ b/test/sampleRUM-enabled.test.js
@@ -149,4 +149,16 @@ describe('sampleRUM', () => {
       expect(window.hlx.rum.weight).to.equal(1);
     });
   });
+
+  describe('initialization', () => {
+    it('window.hlx.rum.id constraints', async () => {
+      sampleRUM();
+
+      const { id } = window.hlx.rum;
+
+      expect(id).to.exist;
+      expect(id.length).to.equal(4);
+      expect(id).to.match(/^[0-9a-z]+$/);
+    });
+  });
 });


### PR DESCRIPTION
Fix #261

Use [crypto.getRandomValues](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues) (fully supported on all browsers) instead of `Math.random` which triggers security concerns - unjustified for this case but logic remains the same and will avoid security complains.

