### PR TITLE
feat: Allow path for posts to be set via data attribute

### DIFF
--- a/src/standalone.js
+++ b/src/standalone.js
@@ -17,10 +17,11 @@ try {
   // eslint-disable-next-line max-len
   const dataAttrs = (document.currentScript && document.currentScript.dataset) ? document.currentScript.dataset : {};
   const {
-    status, enhancerVersion, enhancerHash, ...scriptParams
+    postPath, status, enhancerVersion, enhancerHash, ...scriptParams
   } = dataAttrs;
+  const base = scriptSrc && postPath ? new URL(postPath, scriptSrc) : scriptSrc;
   sampleRUM.enhancerContext = { enhancerVersion, enhancerHash };
-  window.RUM_BASE = window.RUM_BASE || scriptSrc;
+  window.RUM_BASE = window.RUM_BASE || base;
   window.RUM_PARAMS = window.RUM_PARAMS || scriptParams;
 
   const [navigation] = (window.performance && window.performance.getEntriesByType('navigation')) || [];


### PR DESCRIPTION
The standalone script is currently using the origin of the script source as RUM_BASE. With this patch, if a `data-post-path` attribute is set, this path will be appended to RUM_BASE.
