### PR TITLE
Collect OpTel for CSP violations

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,6 +57,16 @@ export function sampleRUM(checkpoint, data) {
           sampleRUM('error', errData);
         });
 
+        window.addEventListener('securitypolicyviolation', (e) => {
+          if (e.blockedURI.includes('helix-rum-enhancer')) {
+            const errData = {
+              source: 'csp',
+              target: e.blockedURI,
+            };
+            sampleRUM.sendPing('error', timeShift(), errData);
+          }
+        });
+
         sampleRUM.baseURL = sampleRUM.baseURL || new URL(window.RUM_BASE || '/', new URL('https://rum.hlx.page'));
         sampleRUM.collectBaseURL = sampleRUM.collectBaseURL || sampleRUM.baseURL;
         sampleRUM.sendPing = (ck, time, pingData = {}) => {

--- a/test/errors/sampleRUM.csp.violation.test.js
+++ b/test/errors/sampleRUM.csp.violation.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Adobe. All rights reserved.
+ * Copyright 2025 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/test/errors/sampleRUM.csp.violation.test.js
+++ b/test/errors/sampleRUM.csp.violation.test.js
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+
+import { assert } from '@esm-bundle/chai';
+import { sampleRUM } from '../../src/index.js';
+
+describe('sampleRUM CSP violation capture', () => {
+  let originalSendBeacon;
+  let capturedCalls;
+
+  beforeEach(() => {
+    // Set up RUM with rum=on parameter
+    const usp = new URLSearchParams(window.location.search);
+    usp.append('rum', 'on');
+    window.history.replaceState({}, '', `${window.location.pathname}?${usp.toString()}`);
+
+    // Mock sendBeacon to capture calls
+    originalSendBeacon = navigator.sendBeacon;
+    capturedCalls = [];
+
+    navigator.sendBeacon = (url, data) => {
+      const parsedData = JSON.parse(data);
+      capturedCalls.push({ url, data: parsedData });
+      return true;
+    };
+
+    // Initialize sampleRUM
+    sampleRUM();
+  });
+
+  afterEach(() => {
+    // Clean up
+    const usp = new URLSearchParams(window.location.search);
+    usp.delete('rum');
+    window.history.replaceState({}, '', `${window.location.pathname}?${usp.toString()}`);
+
+    // eslint-disable-next-line no-underscore-dangle
+    window.hlx.rum = undefined;
+
+    // Restore original sendBeacon
+    navigator.sendBeacon = originalSendBeacon;
+
+    // Remove any enhancer scripts
+    const enhancer = document.querySelector('script[src*="rum-enhancer"]');
+    if (enhancer) {
+      enhancer.remove();
+    }
+  });
+
+  it('should capture CSP violation for helix-rum-enhancer URI', (done) => {
+    // Create a securitypolicyviolation event with helix-rum-enhancer URI
+    const event = new Event('securitypolicyviolation');
+    event.blockedURI = 'https://example.com/helix-rum-enhancer/script.js';
+    event.violatedDirective = 'script-src';
+    event.originalPolicy = 'script-src \'self\'';
+    event.sourceFile = 'https://example.com/page.html';
+    event.lineNumber = 10;
+    event.columnNumber = 5;
+
+    // Dispatch the event
+    window.dispatchEvent(event);
+
+    // Wait a bit for the event to be processed
+    setTimeout(() => {
+      // Find the CSP error call
+      const cspCall = capturedCalls.find((call) => call.data.checkpoint === 'error' && call.data.source === 'csp');
+      assert.ok(cspCall, 'sendBeacon should have been called for CSP violation');
+      assert.strictEqual(cspCall.data.checkpoint, 'error');
+      assert.strictEqual(cspCall.data.source, 'csp');
+      assert.strictEqual(cspCall.data.target, 'https://example.com/helix-rum-enhancer/script.js');
+      assert.ok(cspCall.data.t, 'should have timestamp');
+      assert.ok(cspCall.data.id, 'should have RUM id');
+      assert.strictEqual(cspCall.data.weight, 1);
+      done();
+    }, 100);
+  });
+
+  it('should not capture CSP violation for non-helix-rum-enhancer URI', (done) => {
+    // Create a securitypolicyviolation event with different URI
+    const event = new Event('securitypolicyviolation');
+    event.blockedURI = 'https://example.com/other-script.js';
+    event.violatedDirective = 'script-src';
+    event.originalPolicy = 'script-src \'self\'';
+    event.sourceFile = 'https://example.com/page.html';
+    event.lineNumber = 10;
+    event.columnNumber = 5;
+
+    // Dispatch the event
+    window.dispatchEvent(event);
+
+    // Wait a bit for the event to be processed
+    setTimeout(() => {
+      // Check that no CSP error call was made
+      const cspCall = capturedCalls.find((call) => call.data.checkpoint === 'error' && call.data.source === 'csp');
+      assert.strictEqual(cspCall, undefined, 'sendBeacon should not have been called for non-helix-rum-enhancer URI');
+      done();
+    }, 100);
+  });
+
+  it('should capture CSP violation for URI containing helix-rum-enhancer anywhere in the path', (done) => {
+    // Create a securitypolicyviolation event with helix-rum-enhancer in the middle of the URI
+    const event = new Event('securitypolicyviolation');
+    event.blockedURI = 'https://cdn.example.com/path/to/helix-rum-enhancer/v2/script.js';
+    event.violatedDirective = 'script-src';
+    event.originalPolicy = 'script-src \'self\'';
+    event.sourceFile = 'https://example.com/page.html';
+    event.lineNumber = 10;
+    event.columnNumber = 5;
+
+    // Dispatch the event
+    window.dispatchEvent(event);
+
+    // Wait a bit for the event to be processed
+    setTimeout(() => {
+      // Find the CSP error call
+      const cspCall = capturedCalls.find((call) => call.data.checkpoint === 'error' && call.data.source === 'csp');
+      assert.ok(cspCall, 'sendBeacon should have been called for CSP violation');
+      assert.strictEqual(cspCall.data.checkpoint, 'error');
+      assert.strictEqual(cspCall.data.source, 'csp');
+      assert.strictEqual(cspCall.data.target, 'https://cdn.example.com/path/to/helix-rum-enhancer/v2/script.js');
+      done();
+    }, 100);
+  });
+});

--- a/test/loading/enhance-module-csp.test.html
+++ b/test/loading/enhance-module-csp.test.html
@@ -1,5 +1,10 @@
 <html>
   <head>
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="script-src 'self' 'unsafe-inline'; base-uri 'self'; object-src 'none';"
+      move-to-http-header="true"
+    />
     <script>
       const usp = new URLSearchParams(window.location.search);
       usp.append('rum', 'on');
@@ -18,14 +23,14 @@
       /* eslint-env mocha */
       runTests(async () => {
         describe('enhance', () => {
-          it('rum - load enhancer', () => {
-            // at this stage, rum-enhancer should be loaded
-            assert.ok(document.querySelector('script[src*="rum-enhancer"]'));          
-            assert.match(document.querySelector('script[src*="rum-enhancer"]').src, /rum\.hlx\.page/);
+          it('rum - CSP blocks enhancer loading', () => {
+            // at this stage, rum-enhancer should NOT be loaded due to CSP violation
+            const enhancerScript = document.querySelector('script[src*="rum-enhancer"]');
+            assert.strictEqual(enhancerScript, null, 'helix-rum-enhancer script should be blocked by CSP');
           });
         });
       });
     </script>
-    Test page for rum enhancer loading.  Many checkpoints should be sent, including language, cwv, a11y, etc.
+    Test page for CSP violation.  Only top and error checkpoints should be sent.
   </body>
 </html>

--- a/test/loading/enhance-module-csp.test.html
+++ b/test/loading/enhance-module-csp.test.html
@@ -1,8 +1,9 @@
 <html>
   <head>
+    <!-- CSP policy that blocks rum.hlx.page specifically -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="script-src 'self' 'unsafe-inline'; base-uri 'self'; object-src 'none';"
+      content="script-src 'self' 'unsafe-inline' 'unsafe-eval'; base-uri 'self'; object-src 'none';"
       move-to-http-header="true"
     />
     <script>
@@ -24,9 +25,9 @@
       runTests(async () => {
         describe('enhance', () => {
           it('rum - CSP blocks enhancer loading', () => {
-            // at this stage, rum-enhancer should NOT be loaded due to CSP violation
-            const enhancerScript = document.querySelector('script[src*="rum-enhancer"]');
-            assert.strictEqual(enhancerScript, null, 'helix-rum-enhancer script should be blocked by CSP');
+            // at this stage, rum-enhancer plugins should NOT be loaded due to CSP violation
+            const enhancerPluginScript = document.querySelector('script[src*="cwv.js"]');
+            assert.strictEqual(enhancerPluginScript, null, 'helix-rum-enhancer cwv plugin script should be blocked by CSP');
           });
         });
       });


### PR DESCRIPTION
See description and comments at https://github.com/adobe/aem-boilerplate/pull/545.  This is meant to be the official PR to check for customer implementations blocking the helix-rum-enhancer from loading, and the changes made here to sampleRUM will flow to the copy in aem-boilerplate.  The other PR will be abandoned and was meant for early syntax review.

BEFORE - no test for CSP violation, no error checkpoint with csp source
https://main--helix-rum-js--adobe.aem.page/test/loading/enhance-module.test.html?rum=on

AFTER - test for CSP violation, error checkpoint with csp source
https://csp--helix-rum-js--adobe.aem.page/test/loading/enhance-module-csp.test.html?rum=on
