### PR TITLE
fix(ci): guard against long DNS labels in PR description URL

### DIFF
--- a/.github/workflows/update-pr-description.yaml
+++ b/.github/workflows/update-pr-description.yaml
@@ -20,11 +20,14 @@ jobs:
               repo: context.repo.repo,
               pull_number: context.issue.number
             });
-            // Replace any non-alphanumeric, non-hyphen character with '-' for AEM URLs
-            const branchName = context.payload.pull_request.head.ref.replace(/[^a-zA-Z0-9-]/g, '-');
+            // Sanitize branch name: replace non-alphanumeric chars, collapse consecutive hyphens, trim leading/trailing hyphens
+            const branchName = context.payload.pull_request.head.ref
+              .replace(/[^a-zA-Z0-9-]/g, '-')
+              .replace(/-+/g, '-')
+              .replace(/^-+|-+$/g, '');
             const domainLabel = `${branchName}--helix-rum-js--adobe`;
             const testContent = domainLabel.length > 63
-              ? 'Branch name is too long to generate a valid preview URL (DNS label exceeds 63 characters).'
+              ? `Branch name is too long to generate a valid preview URL (${domainLabel.length}/63 DNS label characters).`
               : `https://${domainLabel}.aem.live/test/static.html`;
             const testSection = `
 

--- a/.github/workflows/update-pr-description.yaml
+++ b/.github/workflows/update-pr-description.yaml
@@ -20,11 +20,8 @@ jobs:
               repo: context.repo.repo,
               pull_number: context.issue.number
             });
-            // Sanitize branch name: replace non-alphanumeric chars, collapse consecutive hyphens, trim leading/trailing hyphens
-            const branchName = context.payload.pull_request.head.ref
-              .replace(/[^a-zA-Z0-9-]/g, '-')
-              .replace(/-+/g, '-')
-              .replace(/^-+|-+$/g, '');
+            // Replace any non-alphanumeric, non-hyphen characters with a single '-' for AEM URLs
+            const branchName = context.payload.pull_request.head.ref.replace(/[^a-zA-Z0-9-]+/g, '-');
             const domainLabel = `${branchName}--helix-rum-js--adobe`;
             const testContent = domainLabel.length > 63
               ? `Branch name is too long to generate a valid preview URL (${domainLabel.length}/63 DNS label characters).`

--- a/.github/workflows/update-pr-description.yaml
+++ b/.github/workflows/update-pr-description.yaml
@@ -20,13 +20,16 @@ jobs:
               repo: context.repo.repo,
               pull_number: context.issue.number
             });
-            // Get the branch name from the PR head ref
+            // Replace any non-alphanumeric, non-hyphen character with '-' for AEM URLs
             const branchName = context.payload.pull_request.head.ref.replace(/[^a-zA-Z0-9-]/g, '-');
-            const testUrl = `https://${branchName}--helix-rum-js--adobe.aem.live/test/static.html`;
+            const domainLabel = `${branchName}--helix-rum-js--adobe`;
+            const testContent = domainLabel.length > 63
+              ? 'Branch name is too long to generate a valid preview URL (DNS label exceeds 63 characters).'
+              : `https://${domainLabel}.aem.live/test/static.html`;
             const testSection = `
 
             ## Test URL
-            ${testUrl}
+            ${testContent}
             `;
 
             // Check if the test section already exists


### PR DESCRIPTION
Skip generating the preview URL when the DNS label would exceed 63 characters, adding an explanatory note to the PR description instead.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!


## Test URL
https://fix-pr-description-url-guard--helix-rum-js--adobe.aem.live/test/static.html
