### PR TITLE
fix: strip query params from referer and referrer source before sending beacon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ logs
 test-results.xml
 .env
 .idea
-test/micro-loader/rum-standalone.js.worktrees
+test/micro-loader/rum-standalone.js
+.worktrees

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ logs
 test-results.xml
 .env
 .idea
-test/micro-loader/rum-standalone.js
+test/micro-loader/rum-standalone.js.worktrees

--- a/src/404.js
+++ b/src/404.js
@@ -20,7 +20,8 @@ try {
   sampleRUM.enhancerContext = { enhancerVersion, enhancerHash };
   window.RUM_BASE = window.RUM_BASE || scriptSrc;
   window.RUM_PARAMS = window.RUM_PARAMS || scriptParams;
-  sampleRUM('404', { source: document.referrer });
+  const { origin = '', pathname = '' } = document.referrer ? new URL(document.referrer) : {};
+  sampleRUM('404', { source: origin + pathname });
 } catch (error) {
   // something went wrong
 }

--- a/src/index.js
+++ b/src/index.js
@@ -80,7 +80,7 @@ export function sampleRUM(checkpoint, data) {
         sampleRUM.collectBaseURL = sampleRUM.collectBaseURL || sampleRUM.baseURL;
         sampleRUM.sendPing = (ck, time, pingData = {}) => {
           // eslint-disable-next-line max-len, object-curly-newline
-          const rumData = JSON.stringify({ weight, id, referer: window.location.href, checkpoint: ck, t: time, ...pingData });
+          const rumData = JSON.stringify({ weight, id, referer: window.location.origin + window.location.pathname, checkpoint: ck, t: time, ...pingData });
           const urlParams = window.RUM_PARAMS ? (new URLSearchParams(window.RUM_PARAMS).toString() || '') : '';
           const { href: url, origin } = new URL(`.rum/${weight}${urlParams ? `?${urlParams}` : ''}`, sampleRUM.collectBaseURL);
           const body = origin === window.location.origin ? new Blob([rumData], { type: 'application/json' }) : rumData;

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -29,7 +29,8 @@ try {
     && navigation.responseStatus === 404);
 
   if (is404) {
-    sampleRUM('404', { source: document.referrer });
+    const { origin = '', pathname = '' } = document.referrer ? new URL(document.referrer) : {};
+    sampleRUM('404', { source: origin + pathname });
   } else {
     sampleRUM();
   }

--- a/test/sampleRUM-enabled.test.js
+++ b/test/sampleRUM-enabled.test.js
@@ -56,6 +56,28 @@ describe('sampleRUM', () => {
     navigator.sendBeacon = navigator._sendBeacon;
   });
 
+  it('top checkpoint referer does not include query params', () => {
+    const sendBeaconArgs = {};
+    // eslint-disable-next-line no-underscore-dangle
+    navigator._sendBeacon = navigator.sendBeacon;
+    navigator.sendBeacon = (url, data) => {
+      sendBeaconArgs.url = url;
+      sendBeaconArgs.data = JSON.parse(data);
+      return true;
+    };
+
+    sampleRUM();
+
+    // beforeEach adds ?rum=on to the URL; referer must still be param-free
+    assert.strictEqual(
+      sendBeaconArgs.data.referer,
+      window.location.origin + window.location.pathname,
+    );
+    assert.ok(!sendBeaconArgs.data.referer.includes('?'), 'referer must not contain query params');
+    // eslint-disable-next-line no-underscore-dangle
+    navigator.sendBeacon = navigator._sendBeacon;
+  });
+
   it('rum sendPing available', () => {
     const sendBeaconArgs = {};
     // eslint-disable-next-line no-underscore-dangle


### PR DESCRIPTION
## Summary

- The `top` checkpoint was sending `window.location.href` (full URL including query params) as the `referer` field. Changed to `window.location.origin + window.location.pathname`.
- The `404` checkpoint in both `404.js` and `standalone.js` was passing `document.referrer` unsanitized as `source`. For same-origin navigation, `document.referrer` includes the full URL with query params. Fixed by extracting only `origin + pathname`.

## Why

The [operational telemetry docs](https://www.aem.live/docs/operational-telemetry) state that URL parameters will not be collected or stored. The collector strips params before storage, but these fields were still transmitting params in the beacon. This aligns client-side behaviour with the documented privacy guarantee.

## Test plan

- [ ] Verify `top` checkpoint `referer` no longer includes query params in beacon
- [ ] Verify `404` checkpoint `source` strips query params from same-origin referrer
- [ ] All existing tests pass (65/65)

Generated with [Claude Code](https://claude.com/claude-code)

## Test URL
https://fix-sanitize-referrer-params-rum--helix-rum-js--adobe.aem.live/test/static.html
