### PR TITLE
feat: annotate webdriver sessions in beacon UA for bot detection

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -79,8 +79,11 @@ export function sampleRUM(checkpoint, data) {
         sampleRUM.baseURL = sampleRUM.baseURL || new URL(window.RUM_BASE || '/', new URL('https://rum.hlx.page'));
         sampleRUM.collectBaseURL = sampleRUM.collectBaseURL || sampleRUM.baseURL;
         sampleRUM.sendPing = (ck, time, pingData = {}) => {
+          const uaExtra = navigator.webdriver && !navigator.userAgent.includes('+http')
+            ? { ua: `${navigator.userAgent} +http://navigator.webdriver` }
+            : {};
           // eslint-disable-next-line max-len, object-curly-newline
-          const rumData = JSON.stringify({ weight, id, referer: window.location.origin + window.location.pathname, checkpoint: ck, t: time, ...pingData });
+          const rumData = JSON.stringify({ weight, id, referer: window.location.origin + window.location.pathname, checkpoint: ck, t: time, ...pingData, ...uaExtra });
           const urlParams = window.RUM_PARAMS ? (new URLSearchParams(window.RUM_PARAMS).toString() || '') : '';
           const { href: url, origin } = new URL(`.rum/${weight}${urlParams ? `?${urlParams}` : ''}`, sampleRUM.collectBaseURL);
           const body = origin === window.location.origin ? new Blob([rumData], { type: 'application/json' }) : rumData;

--- a/test/sampleRUM-webdriver.test.js
+++ b/test/sampleRUM-webdriver.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Adobe. All rights reserved.
+ * Copyright 2026 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/test/sampleRUM-webdriver.test.js
+++ b/test/sampleRUM-webdriver.test.js
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+/* eslint-disable no-unused-expressions */
+
+import { assert } from '@esm-bundle/chai';
+import { sampleRUM } from '../src/index.js';
+
+describe('sampleRUM - webdriver bot detection', () => {
+  beforeEach(() => {
+    const usp = new URLSearchParams(window.location.search);
+    usp.append('rum', 'on');
+    window.history.replaceState({}, '', `${window.location.pathname}?${usp.toString()}`);
+  });
+
+  afterEach(() => {
+    const usp = new URLSearchParams(window.location.search);
+    usp.delete('rum');
+    window.history.replaceState({}, '', `${window.location.pathname}?${usp.toString()}`);
+    // eslint-disable-next-line no-underscore-dangle
+    window.hlx.rum = undefined;
+    delete navigator.webdriver;
+
+    const enhancer = document.querySelector('script[src*="rum-enhancer"]');
+    if (enhancer) {
+      enhancer.remove();
+    }
+  });
+
+  it('adds ua field with +http://navigator.webdriver when navigator.webdriver is true', () => {
+    Object.defineProperty(navigator, 'webdriver', { value: true, configurable: true });
+
+    const sendBeaconArgs = {};
+    // eslint-disable-next-line no-underscore-dangle
+    navigator._sendBeacon = navigator.sendBeacon;
+    navigator.sendBeacon = (url, data) => {
+      sendBeaconArgs.url = url;
+      sendBeaconArgs.data = JSON.parse(data);
+      return true;
+    };
+
+    sampleRUM('top', {});
+
+    assert.ok(sendBeaconArgs.data.ua, 'ua field should be present');
+    assert.ok(
+      sendBeaconArgs.data.ua.includes('+http://navigator.webdriver'),
+      'ua should contain +http://navigator.webdriver',
+    );
+    assert.ok(
+      sendBeaconArgs.data.ua.startsWith(navigator.userAgent.split(' +http')[0]),
+      'ua should start with the real user agent',
+    );
+    // eslint-disable-next-line no-underscore-dangle
+    navigator.sendBeacon = navigator._sendBeacon;
+  });
+
+  it('does not add ua field when navigator.webdriver is false', () => {
+    Object.defineProperty(navigator, 'webdriver', { value: false, configurable: true });
+
+    const sendBeaconArgs = {};
+    // eslint-disable-next-line no-underscore-dangle
+    navigator._sendBeacon = navigator.sendBeacon;
+    navigator.sendBeacon = (url, data) => {
+      sendBeaconArgs.url = url;
+      sendBeaconArgs.data = JSON.parse(data);
+      return true;
+    };
+
+    sampleRUM('top', {});
+
+    assert.isUndefined(sendBeaconArgs.data.ua, 'ua field should not be present for normal browsers');
+    // eslint-disable-next-line no-underscore-dangle
+    navigator.sendBeacon = navigator._sendBeacon;
+  });
+
+  it('does not add ua field when userAgent already contains +http', () => {
+    Object.defineProperty(navigator, 'webdriver', { value: true, configurable: true });
+    const originalUA = navigator.userAgent;
+    Object.defineProperty(navigator, 'userAgent', {
+      value: `${originalUA} +http://some-existing-bot-disclosure`,
+      configurable: true,
+    });
+
+    const sendBeaconArgs = {};
+    // eslint-disable-next-line no-underscore-dangle
+    navigator._sendBeacon = navigator.sendBeacon;
+    navigator.sendBeacon = (url, data) => {
+      sendBeaconArgs.url = url;
+      sendBeaconArgs.data = JSON.parse(data);
+      return true;
+    };
+
+    sampleRUM('top', {});
+
+    assert.isUndefined(sendBeaconArgs.data.ua, 'ua field should not be added when UA already discloses bot via +http');
+    // eslint-disable-next-line no-underscore-dangle
+    navigator.sendBeacon = navigator._sendBeacon;
+    Object.defineProperty(navigator, 'userAgent', { value: originalUA, configurable: true });
+  });
+});


### PR DESCRIPTION
## Summary

- Automated browsers (Selenium, Playwright, Puppeteer) use real browser user-agent strings and pass server-side bot detection undetected
- When `navigator.webdriver` is `true` and the UA doesn't already self-disclose via `+http`, appends `+http://navigator.webdriver` to a `ua` field in the beacon JSON payload
- The collector's existing `+http://` detection path classifies these sessions as `bot` — no collector-side changes needed for the base case
- Traffic is **collected, not suppressed**, so webdriver bot volume can be estimated and excluded in reporting as needed

## Test plan

- [ ] `test/sampleRUM-webdriver.test.js`: `navigator.webdriver = true` → `ua` field present with `+http://navigator.webdriver` suffix
- [ ] `navigator.webdriver = true` but UA already contains `+http` → no `ua` field added (avoids double-annotating bots that already self-disclose)
- [ ] `navigator.webdriver = false/undefined` → no `ua` field added
- [ ] All 69 existing tests continue to pass

Companion PR in helix-rum-collector: adobe/helix-rum-collector#feat/webdriver-bot-detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Test URL
https://feat-webdriver-bot-detection--helix-rum-js--adobe.aem.live/test/static.html
