### PR TITLE
fix: revert default sampling rate back to 1:100

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ export function sampleRUM(checkpoint, data) {
         medium: 100,
         low: 1000,
       }[rate];
-      const weight = rateValue !== undefined ? rateValue : 1000;
+      const weight = rateValue !== undefined ? rateValue : 100;
       const id = (window.hlx.rum && window.hlx.rum.id)
         || crypto.randomUUID().slice(-9);
       const isSelected = (window.hlx.rum && window.hlx.rum.isSelected)

--- a/src/micro.js
+++ b/src/micro.js
@@ -10,7 +10,7 @@ var c = document.currentScript,
   v = q.get('rum') || q.get('optel') || d.rate,
   // w is the rate of the current script element
   t = { on: 1, off: 0, high: 10, low: 1e3 }[v],
-  w = t !== undefined ? t : 1000,
+  w = t !== undefined ? t : 100,
   // r is the rum object, we initialize it if it doesn't exist
   r = (window.hlx = window.hlx || {}).rum ||
     // generate a random id for the rum object

--- a/test/micro-loader/optel-default.test.html
+++ b/test/micro-loader/optel-default.test.html
@@ -32,10 +32,10 @@
     /* eslint-env mocha */
     runTests(async () => {
       describe('Operational Telemetry - Micro-Loader', () => {
-        it('when set to anything, sets it to 1000', async () => {
+        it('when set to anything, sets it to 100', async () => {
           await new Promise(resolve => setTimeout(resolve, 500));
           const event = window.events[0];
-          assert.strictEqual(event.weight, 1000);
+          assert.strictEqual(event.weight, 100);
           assert.strictEqual(event.checkpoint, 'top')
           assert.include(event.referer, 'optel-default.test.html');
         });

--- a/test/sampleRUM-disabled.test.js
+++ b/test/sampleRUM-disabled.test.js
@@ -105,10 +105,10 @@ describe('sampleRUM - RUM disabled', () => {
       sampleRUM();
       assert.strictEqual(window.hlx.rum.weight, 1000);
     });
-    it('defaults to 1000 sampling rate', async () => {
+    it('defaults to 100 sampling rate', async () => {
       delete window.SAMPLE_PAGEVIEWS_AT_RATE;
       sampleRUM();
-      assert.strictEqual(window.hlx.rum.weight, 1000);
+      assert.strictEqual(window.hlx.rum.weight, 100);
     });
   });
 });

--- a/test/sampleRUM-optel.test.js
+++ b/test/sampleRUM-optel.test.js
@@ -173,14 +173,14 @@ describe('sampleRUM - optel parameter', () => {
   });
 
   describe('default weight when optel has invalid value', () => {
-    it('defaults to weight 1000 for invalid optel value', () => {
+    it('defaults to weight 100 for invalid optel value', () => {
       const usp = new URLSearchParams(window.location.search);
       usp.append('optel', 'invalid');
       window.history.replaceState({}, '', `${window.location.pathname}?${usp.toString()}`);
 
       sampleRUM();
 
-      assert.strictEqual(window.hlx.rum.weight, 1000);
+      assert.strictEqual(window.hlx.rum.weight, 100);
     });
   });
 });


### PR DESCRIPTION
## Summary

Reverts the changes introduced by #340, #341, and #342, which changed the default RUM sampling rate from **1:100** to **1:1000**.

| PR | Change | Reverted |
|----|--------|----------|
| #340 | `src/micro.js` default `100` → `1000` | ✅ restored to `100` |
| #341 | `src/index.js` default `100` → `1000` + `medium: 100` mapping + test updates | ✅ default restored to `100` (the `medium: 100` mapping is **kept**) + tests reverted |
| #342 | empty release-trigger commit (no code) | n/a — nothing to revert |

### Notes
- The `medium: 100` rate mapping added in #341 is intentionally **kept**, since it's a useful named rate should we decide to move the default back to 1:1000 later.
- This is a `fix:` commit so semantic-release will cut a patch release that restores the previous default behavior.

### Testing
- `npm run lint` ✅
- `npm test` ✅ — 69 passed, 0 failed, 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Test URL
https://revert-default-rate-1000--helix-rum-js--adobe.aem.live/test/static.html
